### PR TITLE
[refactor] : 예매 가능한 날짜, 회차 정보 조회 API 관련 테스트 리팩토링

### DIFF
--- a/api/src/test/java/dev/hooon/show/ShowApiControllerTest.java
+++ b/api/src/test/java/dev/hooon/show/ShowApiControllerTest.java
@@ -2,26 +2,44 @@ package dev.hooon.show;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import dev.hooon.common.fixture.SeatFixture;
 import dev.hooon.common.support.ApiTestSupport;
+import dev.hooon.show.domain.entity.seat.Seat;
+import dev.hooon.show.domain.repository.SeatRepository;
 
 @DisplayName("[ShowApiController API 테스트]")
-@Sql("/sql/seat_dummy.sql")
 class ShowApiControllerTest extends ApiTestSupport {
 
 	@Autowired
 	private MockMvc mockMvc;
+	@Autowired
+	private SeatRepository seatRepository;
 
 	@Test
 	@DisplayName("[공연 아이디를 통해 API 를 호출하면 해당 공연의 예매 가능한 날짜와 회차 정보를 응답한다]")
 	void getAbleBookingDateRoundInfoTest() throws Exception {
+		//given
+		LocalTime time = LocalTime.of(12, 34, 56);
+		LocalDate date = LocalDate.of(2023, 10, 10);
+		List<Seat> seats = List.of(
+			SeatFixture.getSeat(date, 1, time),
+			SeatFixture.getSeat(date, 1, time),
+			SeatFixture.getSeat(date.plusDays(1), 1, time.plusHours(1)),
+			SeatFixture.getSeat(date.plusDays(1), 1, time.plusHours(1))
+		);
+		seatRepository.saveAll(seats);
+
 		//when
 		ResultActions actions = mockMvc.perform(
 			MockMvcRequestBuilders
@@ -35,9 +53,9 @@ class ShowApiControllerTest extends ApiTestSupport {
 			jsonPath("$.availableDates[0].showDate").value("2023-10-10"),
 			jsonPath("$.availableDates[0].round").value(1),
 			jsonPath("$.availableDates[0].startTime").value("12:34:56"),
-			jsonPath("$.availableDates[1].showDate").value("2023-10-10"),
-			jsonPath("$.availableDates[1].round").value(2),
-			jsonPath("$.availableDates[1].startTime").value("14:34:56")
+			jsonPath("$.availableDates[1].showDate").value("2023-10-11"),
+			jsonPath("$.availableDates[1].round").value(1),
+			jsonPath("$.availableDates[1].startTime").value("13:34:56")
 		);
 	}
 }

--- a/core/src/main/java/dev/hooon/common/exception/CommonValidationError.java
+++ b/core/src/main/java/dev/hooon/common/exception/CommonValidationError.java
@@ -1,0 +1,19 @@
+package dev.hooon.common.exception;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class CommonValidationError {
+
+	private static final String NOT_NULL_POSTFIX = " 는 Null 이 될 수 없습니다";
+	private static final String NOT_EMPTY_POSTFIX = " 는 Empty 가 될 수 없습니다";
+
+	public static String getNotNullMessage(String object, String variable) {
+		return object + "_" + variable + NOT_NULL_POSTFIX;
+	}
+
+	public static String getNotEmptyPostfix(String object, String variable) {
+		return object + "_" + variable + NOT_EMPTY_POSTFIX;
+	}
+}

--- a/core/src/main/java/dev/hooon/show/domain/entity/Show.java
+++ b/core/src/main/java/dev/hooon/show/domain/entity/Show.java
@@ -4,7 +4,6 @@ import static jakarta.persistence.ConstraintMode.*;
 import static jakarta.persistence.EnumType.*;
 import static jakarta.persistence.FetchType.*;
 import static jakarta.persistence.GenerationType.*;
-import static lombok.AccessLevel.*;
 
 import dev.hooon.common.entity.TimeBaseEntity;
 import dev.hooon.show.domain.entity.place.Place;
@@ -24,7 +23,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @Table(name = "show_table")
-@NoArgsConstructor(access = PROTECTED)
+@NoArgsConstructor
 public class Show extends TimeBaseEntity {
 
     @Id

--- a/core/src/main/java/dev/hooon/show/domain/entity/place/Place.java
+++ b/core/src/main/java/dev/hooon/show/domain/entity/place/Place.java
@@ -1,7 +1,6 @@
 package dev.hooon.show.domain.entity.place;
 
 import static jakarta.persistence.GenerationType.*;
-import static lombok.AccessLevel.*;
 
 import dev.hooon.common.entity.TimeBaseEntity;
 import jakarta.persistence.Column;
@@ -15,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @Table(name = "place_table")
-@NoArgsConstructor(access = PROTECTED)
+@NoArgsConstructor
 public class Place extends TimeBaseEntity {
 
     @Id

--- a/core/src/main/java/dev/hooon/show/domain/entity/seat/Seat.java
+++ b/core/src/main/java/dev/hooon/show/domain/entity/seat/Seat.java
@@ -1,5 +1,6 @@
 package dev.hooon.show.domain.entity.seat;
 
+import static dev.hooon.common.exception.CommonValidationError.*;
 import static jakarta.persistence.ConstraintMode.*;
 import static jakarta.persistence.EnumType.*;
 import static jakarta.persistence.FetchType.*;
@@ -7,6 +8,9 @@ import static jakarta.persistence.GenerationType.*;
 import static lombok.AccessLevel.*;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
+
+import org.springframework.util.Assert;
 
 import dev.hooon.common.entity.TimeBaseEntity;
 import dev.hooon.show.domain.entity.Show;
@@ -28,6 +32,8 @@ import lombok.NoArgsConstructor;
 @Table(name = "seat_table")
 @NoArgsConstructor(access = PROTECTED)
 public class Seat extends TimeBaseEntity {
+
+    private static final String SEAT = "seat";
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
@@ -60,4 +66,58 @@ public class Seat extends TimeBaseEntity {
     @Enumerated(STRING)
     @Column(name = "seat_status", nullable = false)
     private SeatStatus seatStatus;
+
+    private Seat(
+        Show show,
+        SeatGrade seatGrade,
+        boolean isSeat,
+        String sector,
+        String row,
+        int col,
+        int price,
+        LocalDate showDate,
+        int round,
+        LocalTime startTime,
+        SeatStatus seatStatus
+    ) {
+        Assert.notNull(show, getNotNullMessage(SEAT, "show"));
+        Assert.notNull(seatGrade, getNotNullMessage(SEAT, "seatGrade"));
+        Assert.hasText(sector, getNotEmptyPostfix(SEAT, "sector"));
+        Assert.hasText(row, getNotEmptyPostfix(SEAT, "row"));
+        Assert.notNull(showDate, getNotNullMessage(SEAT, "showDate"));
+        Assert.notNull(startTime, getNotNullMessage(SEAT, "startTime"));
+        Assert.notNull(seatStatus, getNotNullMessage(SEAT, "seatStatus"));
+        this.show = show;
+        this.seatGrade = seatGrade;
+        this.isSeat = isSeat;
+        this.positionInfo = new SeatPositionInfo(sector, row, col);
+        this.price = price;
+        this.showDate = showDate;
+        this.showRound = new ShowRound(round, startTime);
+        this.seatStatus = seatStatus;
+    }
+
+    public static Seat of(
+        Show show,
+        SeatGrade seatGrade,
+        boolean isSeat,
+        String sector,
+        String row,
+        int col,
+        int price,
+        LocalDate showDate,
+        int round,
+        LocalTime startTime,
+        SeatStatus seatStatus
+    ) {
+        return new Seat(show, seatGrade, isSeat, sector, row, col, price, showDate, round, startTime, seatStatus);
+    }
+
+    public int getRound() {
+        return showRound.getRound();
+    }
+
+    public LocalTime getStartTime() {
+        return showRound.getStartTime();
+    }
 }

--- a/core/src/main/java/dev/hooon/show/domain/entity/seat/SeatPositionInfo.java
+++ b/core/src/main/java/dev/hooon/show/domain/entity/seat/SeatPositionInfo.java
@@ -22,4 +22,14 @@ public class SeatPositionInfo {
 
     @Column(name = "seat_col", nullable = false)
     private int col;
+
+    public SeatPositionInfo(
+        String sector,
+        String row,
+        int col
+    ) {
+        this.sector = sector;
+        this.row = row;
+        this.col = col;
+    }
 }

--- a/core/src/main/java/dev/hooon/show/domain/entity/seat/ShowRound.java
+++ b/core/src/main/java/dev/hooon/show/domain/entity/seat/ShowRound.java
@@ -25,4 +25,9 @@ public class ShowRound {
     @Column(name = "seat_start_time")
     @Convert(converter = Jsr310JpaConverters.LocalTimeConverter.class)
     private LocalTime startTime;
+
+    public ShowRound(int round, LocalTime startTime) {
+        this.round = round;
+        this.startTime = startTime;
+    }
 }

--- a/core/src/main/java/dev/hooon/show/domain/repository/SeatRepository.java
+++ b/core/src/main/java/dev/hooon/show/domain/repository/SeatRepository.java
@@ -2,9 +2,11 @@ package dev.hooon.show.domain.repository;
 
 import java.util.List;
 
+import dev.hooon.show.domain.entity.seat.Seat;
 import dev.hooon.show.dto.query.SeatDateRoundDto;
 
 public interface SeatRepository {
 
+	void saveAll(List<Seat> seats);
 	List<SeatDateRoundDto> findSeatDateRoundInfoByShowId(Long showId);
 }

--- a/core/src/main/java/dev/hooon/show/domain/repository/SeatRepository.java
+++ b/core/src/main/java/dev/hooon/show/domain/repository/SeatRepository.java
@@ -7,6 +7,7 @@ import dev.hooon.show.dto.query.SeatDateRoundDto;
 
 public interface SeatRepository {
 
-	void saveAll(List<Seat> seats);
+	void saveAll(Iterable<Seat> seats);
+
 	List<SeatDateRoundDto> findSeatDateRoundInfoByShowId(Long showId);
 }

--- a/core/src/main/java/dev/hooon/show/infrastructure/SeatJpaRepository.java
+++ b/core/src/main/java/dev/hooon/show/infrastructure/SeatJpaRepository.java
@@ -12,6 +12,11 @@ import dev.hooon.show.dto.query.SeatDateRoundDto;
 public interface SeatJpaRepository extends JpaRepository<Seat, Long>, SeatRepository {
 
 	@Override
+	default void saveAll(List<Seat> seats) {
+		seats.forEach(this::save);
+	}
+
+	@Override
 	@Query("""
 		select distinct
 		new dev.hooon.show.dto.query.SeatDateRoundDto(s.showDate, s.showRound.round, s.showRound.startTime)

--- a/core/src/main/java/dev/hooon/show/infrastructure/adaptor/SeatRepositoryAdaptor.java
+++ b/core/src/main/java/dev/hooon/show/infrastructure/adaptor/SeatRepositoryAdaptor.java
@@ -1,0 +1,28 @@
+package dev.hooon.show.infrastructure.adaptor;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import dev.hooon.show.domain.entity.seat.Seat;
+import dev.hooon.show.domain.repository.SeatRepository;
+import dev.hooon.show.dto.query.SeatDateRoundDto;
+import dev.hooon.show.infrastructure.repository.SeatJpaRepository;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class SeatRepositoryAdaptor implements SeatRepository {
+
+	private final SeatJpaRepository seatJpaRepository;
+
+	@Override
+	public void saveAll(Iterable<Seat> seats) {
+		seatJpaRepository.saveAll(seats);
+	}
+
+	@Override
+	public List<SeatDateRoundDto> findSeatDateRoundInfoByShowId(Long showId) {
+		return seatJpaRepository.findSeatDateRoundInfoByShowId(showId);
+	}
+}

--- a/core/src/main/java/dev/hooon/show/infrastructure/repository/SeatJpaRepository.java
+++ b/core/src/main/java/dev/hooon/show/infrastructure/repository/SeatJpaRepository.java
@@ -1,4 +1,4 @@
-package dev.hooon.show.infrastructure;
+package dev.hooon.show.infrastructure.repository;
 
 import java.util.List;
 
@@ -6,17 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import dev.hooon.show.domain.entity.seat.Seat;
-import dev.hooon.show.domain.repository.SeatRepository;
 import dev.hooon.show.dto.query.SeatDateRoundDto;
 
-public interface SeatJpaRepository extends JpaRepository<Seat, Long>, SeatRepository {
+public interface SeatJpaRepository extends JpaRepository<Seat, Long> {
 
-	@Override
-	default void saveAll(List<Seat> seats) {
-		seats.forEach(this::save);
-	}
-
-	@Override
 	@Query("""
 		select distinct
 		new dev.hooon.show.dto.query.SeatDateRoundDto(s.showDate, s.showRound.round, s.showRound.startTime)

--- a/core/src/test/java/dev/hooon/common/support/DataJpaTestSupport.java
+++ b/core/src/test/java/dev/hooon/common/support/DataJpaTestSupport.java
@@ -4,8 +4,10 @@ import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTest
 
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.stereotype.Repository;
 
-@DataJpaTest
+@DataJpaTest(includeFilters = @ComponentScan.Filter(Repository.class)) // Adaptor 를 스캔목록에 추가하기 위한 코드
 @AutoConfigureTestDatabase(replace = NONE)
 public abstract class DataJpaTestSupport extends TestContainerSupport {
 }

--- a/core/src/test/java/dev/hooon/show/domain/repository/SeatRepositoryTest.java
+++ b/core/src/test/java/dev/hooon/show/domain/repository/SeatRepositoryTest.java
@@ -3,37 +3,53 @@ package dev.hooon.show.domain.repository;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.jdbc.Sql;
 
+import dev.hooon.common.fixture.SeatFixture;
 import dev.hooon.common.support.DataJpaTestSupport;
+import dev.hooon.show.domain.entity.seat.Seat;
 import dev.hooon.show.dto.query.SeatDateRoundDto;
 
-@DisplayName("[SeatRepository 테스트]")
-@Sql("/sql/seat_dummy.sql") // Seat 에 대한 생성자가 없어서 save 를 직접 못해서 쿼리로 더미데이터 추가
+@DisplayName("[SeatJpaRepository 테스트]")
 class SeatRepositoryTest extends DataJpaTestSupport {
 
 	@Autowired
 	private SeatRepository seatRepository;
 
+	private void assertSeatDateRoundDto(SeatDateRoundDto dto, Seat expected) {
+		assertAll(
+			() -> assertThat(dto.showDate()).isEqualTo(expected.getShowDate()),
+			() -> assertThat(dto.round()).isEqualTo(expected.getRound()),
+			() -> assertThat(dto.startTime()).isEqualTo(expected.getStartTime())
+		);
+	}
+
 	@Test
-	@DisplayName("[show_id 로 좌석의 날짜, 회차, 시간 정보를 조회한다]")
+	@DisplayName("[show_id 로 좌석의 (날짜, 회차, 시간) 정보를 중복없이 (날짜, 회차)로 정렬 조회한다]")
 	void findSeatDateRoundInfoByShowIdTest() {
+		//given
+		LocalTime time = LocalTime.of(12, 34, 56);
+		List<Seat> seats = List.of(
+			SeatFixture.getSeat(LocalDate.now(), 1, time),
+			SeatFixture.getSeat(LocalDate.now(), 1, time),
+			SeatFixture.getSeat(LocalDate.now().plusDays(1), 1, time.plusHours(1)),
+			SeatFixture.getSeat(LocalDate.now().plusDays(1), 2, time.plusHours(1))
+		);
+		seatRepository.saveAll(seats);
+
 		//when
 		List<SeatDateRoundDto> result = seatRepository.findSeatDateRoundInfoByShowId(1L);
 
 		//then
-		assertThat(result).hasSize(2);
-		SeatDateRoundDto seatInfo1 = result.get(0);
-		SeatDateRoundDto seatInfo2 = result.get(1);
-		assertAll(
-			() -> assertThat(seatInfo1.showDate()).isEqualTo(seatInfo2.showDate()),
-			() -> assertThat(seatInfo1.round()).isLessThan(seatInfo2.round()),
-			() -> assertThat(seatInfo1.startTime()).isBefore(seatInfo2.startTime())
-		);
+		assertThat(result).hasSize(3);
+		assertSeatDateRoundDto(result.get(0), seats.get(0));
+		assertSeatDateRoundDto(result.get(1), seats.get(2));
+		assertSeatDateRoundDto(result.get(2), seats.get(3));
 	}
 }

--- a/core/src/testFixtures/java/dev/hooon/common/fixture/SeatFixture.java
+++ b/core/src/testFixtures/java/dev/hooon/common/fixture/SeatFixture.java
@@ -1,0 +1,41 @@
+package dev.hooon.common.fixture;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+import dev.hooon.show.domain.entity.Show;
+import dev.hooon.show.domain.entity.seat.Seat;
+import dev.hooon.show.domain.entity.seat.SeatGrade;
+import dev.hooon.show.domain.entity.seat.SeatStatus;
+
+/**
+ * 동일한 타입을 리턴하는 메소드는 오버라이딩으로 구현
+ * 불가능한 경우에만 별도의 메소드 명명
+ */
+public class SeatFixture {
+
+	private SeatFixture() {
+	}
+
+	// show 에 대한 정보가 필요없는 경우에 사용
+	public static Seat getSeat(LocalDate showDate, int round, LocalTime startTime) {
+		Show show = new Show();
+		ReflectionTestUtils.setField(show, "id", 1L);
+
+		return Seat.of(
+			show,
+			SeatGrade.VIP,
+			true,
+			"1층",
+			"A",
+			10,
+			100000,
+			showDate,
+			round,
+			startTime,
+			SeatStatus.AVAILABLE
+		);
+	}
+}

--- a/core/src/testFixtures/resources/sql/seat_dummy.sql
+++ b/core/src/testFixtures/resources/sql/seat_dummy.sql
@@ -1,9 +1,0 @@
-insert into seat_table(seat_id, seat_show_id, seat_grade, seat_is_seat, seat_row, seat_col, seat_price,
-                       seat_show_date, seat_status, seat_show_round, seat_start_time)
-values (1, 1, 'VIP', true, 'A', 1, 1000, DATE('2023-10-10'), 'AVAILABLE', 2, '2023-10-10 14:34:56'::timestamp);
-insert into seat_table(seat_id, seat_show_id, seat_grade, seat_is_seat, seat_row, seat_col, seat_price,
-                       seat_show_date, seat_status, seat_show_round, seat_start_time)
-values (2, 1, 'VIP', true, 'A', 2, 1000, DATE('2023-10-10'), 'AVAILABLE', 1, '2023-10-10 12:34:56'::timestamp);
-insert into seat_table(seat_id, seat_show_id, seat_grade, seat_is_seat, seat_row, seat_col, seat_price,
-                       seat_show_date, seat_status, seat_show_round, seat_start_time)
-values (3, 1, 'VIP', true, 'A', 3, 1000, DATE('2023-10-10'), 'AVAILABLE', 1, '2023-10-10 12:34:56'::timestamp);


### PR DESCRIPTION
## 📄 무엇을 개발했나요? 
* Seat 엔티티 생성로직 구현
* SeatRepository `saveAll` 메소드 구현
* 새롭게 구성한 생성 로직으로 `SeatRepositoryTest`, `ShowApiControllerTest` 리팩토링

## 🍸 무엇을 집중적으로 리뷰해야할까요?
* 3de5feb90544a30272c3da0a1b15dc69f5c728cf 커밋에 있는 템플릿 클래스와 메소드 네이밍 괜찮은지 봐주시면 좋을 것 같아요
* Show, Seat, Place 엔티티 기본생성자 PUBLIC 으로 열어놨습니다. 다른 엔티티도 필요하면 열면 될것같아요
* 나머지는 위에 적어둔 개발한 부분 위주로 보시면 될 것같아요