### PR TITLE
[feat] : 예약 대기 도메인 도메인 계층 구현(엔티티, 레포지토리)

### DIFF
--- a/core/src/main/java/dev/hooon/waitingbooking/domain/entity/WaitingBooking.java
+++ b/core/src/main/java/dev/hooon/waitingbooking/domain/entity/WaitingBooking.java
@@ -1,0 +1,48 @@
+package dev.hooon.waitingbooking.domain.entity;
+
+import static jakarta.persistence.CascadeType.*;
+import static jakarta.persistence.ConstraintMode.*;
+import static jakarta.persistence.FetchType.*;
+import static jakarta.persistence.GenerationType.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.hooon.common.entity.TimeBaseEntity;
+import dev.hooon.user.domain.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "waiting_booking_table")
+@NoArgsConstructor
+public class WaitingBooking extends TimeBaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	@Column(name = "waiting_booking_id")
+	private Long id;
+
+	@Column(name = "waiting_booking_status", nullable = false)
+	private WaitingStatus status;
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(
+		name = "waiting_booking_user_id",
+		nullable = false,
+		foreignKey = @ForeignKey(value = NO_CONSTRAINT))
+	private User user;
+
+	@OneToMany(mappedBy = "waitingBooking", cascade = {REMOVE, PERSIST})
+	List<WaitingBookingSeat> waitingBookingSeats = new ArrayList<>();
+}

--- a/core/src/main/java/dev/hooon/waitingbooking/domain/entity/WaitingBookingSeat.java
+++ b/core/src/main/java/dev/hooon/waitingbooking/domain/entity/WaitingBookingSeat.java
@@ -1,0 +1,38 @@
+package dev.hooon.waitingbooking.domain.entity;
+
+import static jakarta.persistence.ConstraintMode.*;
+import static jakarta.persistence.FetchType.*;
+import static jakarta.persistence.GenerationType.*;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "waiting_booking_seat_table")
+@NoArgsConstructor
+public class WaitingBookingSeat {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	@Column(name = "waiting_booking_seat_id")
+	private Long id;
+
+	@Column(name = "waiting_booking_seat_seat_id")
+	private Long seatId;
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(
+		name = "waiting_booking_seat_waiting_booking_id",
+		nullable = false,
+		foreignKey = @ForeignKey(value = NO_CONSTRAINT))
+	private WaitingBooking waitingBooking;
+}

--- a/core/src/main/java/dev/hooon/waitingbooking/domain/entity/WaitingStatus.java
+++ b/core/src/main/java/dev/hooon/waitingbooking/domain/entity/WaitingStatus.java
@@ -1,0 +1,23 @@
+package dev.hooon.waitingbooking.domain.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum WaitingStatus {
+
+	/**
+	 * 	   			예약 가능 여부 | 시간 만료
+	 * WAITING     			 X | X
+	 * ACTIVATION  			 O | O
+	 * EXPIRED				 X | O
+	 * FIN					 X | X
+	 */
+	WAITING("대기"),
+	ACTIVATION("활성"),
+	EXPIRED("만료"),
+	FIN("종료");
+
+	private final String description;
+}

--- a/core/src/main/java/dev/hooon/waitingbooking/domain/repository/WaitingBookingRepository.java
+++ b/core/src/main/java/dev/hooon/waitingbooking/domain/repository/WaitingBookingRepository.java
@@ -1,0 +1,8 @@
+package dev.hooon.waitingbooking.domain.repository;
+
+import dev.hooon.waitingbooking.domain.entity.WaitingBooking;
+
+public interface WaitingBookingRepository {
+
+	void save(WaitingBooking waitingBooking);
+}

--- a/core/src/main/java/dev/hooon/waitingbooking/infrastructure/adaptor/WaitingBookingRepositoryAdaptor.java
+++ b/core/src/main/java/dev/hooon/waitingbooking/infrastructure/adaptor/WaitingBookingRepositoryAdaptor.java
@@ -1,0 +1,20 @@
+package dev.hooon.waitingbooking.infrastructure.adaptor;
+
+import org.springframework.stereotype.Repository;
+
+import dev.hooon.waitingbooking.domain.entity.WaitingBooking;
+import dev.hooon.waitingbooking.domain.repository.WaitingBookingRepository;
+import dev.hooon.waitingbooking.infrastructure.repository.WaitingBookingJpaRepository;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class WaitingBookingRepositoryAdaptor implements WaitingBookingRepository {
+
+	private final WaitingBookingJpaRepository waitingBookingJpaRepository;
+
+	@Override
+	public void save(WaitingBooking waitingBooking) {
+		waitingBookingJpaRepository.save(waitingBooking);
+	}
+}

--- a/core/src/main/java/dev/hooon/waitingbooking/infrastructure/repository/WaitingBookingJpaRepository.java
+++ b/core/src/main/java/dev/hooon/waitingbooking/infrastructure/repository/WaitingBookingJpaRepository.java
@@ -1,0 +1,8 @@
+package dev.hooon.waitingbooking.infrastructure.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import dev.hooon.waitingbooking.domain.entity.WaitingBooking;
+
+public interface WaitingBookingJpaRepository extends JpaRepository<WaitingBooking, Long> {
+}


### PR DESCRIPTION
## 📄 무엇을 개발했나요? 
* WaitingBooking 도메인 엔티티 구현(WaitingBooking, WaitingBookingSeat)
* WaitingBooking 레포지토리 구현 (JPA + Adaptor)

## 🍸 무엇을 집중적으로 리뷰해야할까요?
* 엔티티 네이밍 봐주시면 좋을 것 같고, @Column 어노테이션 안에 있는 name 이 컨벤션대로 하니까 좀 길고 중복 워딩이 좀 있어서 의견을 좀 듣고싶네요 (저는 그대로 사용해도 괜찮을 것 같습니다)
* WaitingBookingSeat 엔티티는 Seat 엔티티에서 WaitingBooking 으로 연관관계가 부자연스러운 것 같아서 별도로 만든 테이블이며 seatId 말고는 필요한 정보가 없을 것 같아서 객체참조를 하지 않았습니다