### PR TITLE
[feat] : 회원가입 api 구현 & use 엔티티 추가 구현

### DIFF
--- a/api/src/main/java/dev/hooon/user/UserApiController.java
+++ b/api/src/main/java/dev/hooon/user/UserApiController.java
@@ -1,0 +1,32 @@
+package dev.hooon.user;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import dev.hooon.user.application.UserService;
+import dev.hooon.user.dto.request.UserJoinRequestDto;
+import dev.hooon.user.dto.response.UserJoinResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping
+@RequiredArgsConstructor
+public class UserApiController {
+
+	private final UserService userService;
+
+	@PostMapping("/api/users/new")
+	public ResponseEntity<UserJoinResponseDto> join(
+		final @Valid @RequestBody UserJoinRequestDto userJoinRequestDto
+	) {
+		Long userId = userService.join(userJoinRequestDto);
+		return ResponseEntity.ok(new UserJoinResponseDto(userId));
+	}
+
+}

--- a/api/src/test/java/dev/hooon/user/UserApiControllerTest.java
+++ b/api/src/test/java/dev/hooon/user/UserApiControllerTest.java
@@ -1,0 +1,7 @@
+package dev.hooon.user;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserApiControllerTest {
+
+}

--- a/core/src/main/java/dev/hooon/user/application/UserService.java
+++ b/core/src/main/java/dev/hooon/user/application/UserService.java
@@ -2,13 +2,21 @@ package dev.hooon.user.application;
 
 import static dev.hooon.user.exception.UserErrorCode.*;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import dev.hooon.common.exception.NotFoundException;
 import dev.hooon.user.domain.entity.User;
+import dev.hooon.user.domain.entity.UserMapper;
 import dev.hooon.user.domain.repository.UserRepository;
+import dev.hooon.user.dto.request.UserJoinRequestDto;
+import dev.hooon.user.exception.UserException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -18,5 +26,20 @@ public class UserService {
 	public User getUserById(Long userId) {
 		return userRepository.findById(userId)
 			.orElseThrow(() -> new NotFoundException(NOT_FOUND_BY_ID));
+	}
+
+	@Transactional
+	public Long join(UserJoinRequestDto userJoinRequestDto) {
+		validateDuplicateUser(userJoinRequestDto);
+		User user = UserMapper.toBuyerUser(userJoinRequestDto);
+		return userRepository.save(user);
+	}
+
+	private void validateDuplicateUser(UserJoinRequestDto userJoinRequestDto) {
+		List<User> findUsers = userRepository.findByName(userJoinRequestDto.name());
+		if (!findUsers.isEmpty()) {
+			log.info(DUPLICATED_USER.getMessage());
+			throw new UserException(DUPLICATED_USER);
+		}
 	}
 }

--- a/core/src/main/java/dev/hooon/user/domain/entity/User.java
+++ b/core/src/main/java/dev/hooon/user/domain/entity/User.java
@@ -13,25 +13,50 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor
 @Table(name = "user_table")
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends TimeBaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = IDENTITY)
-    @Column(name = "user_id")
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	@Column(name = "user_id")
+	private Long id;
 
-    @Column(name = "user_email", nullable = false, unique = true)
-    private String email;
+	@Column(name = "user_email", nullable = false, unique = true)
+	private String email;
 
-    @Column(name = "user_name", nullable = false)
-    private String name;
+	@Column(name = "user_name", nullable = false)
+	private String name;
 
-    @Enumerated(STRING)
-    @Column(name = "user_role", nullable = false)
-    private UserRole userRole;
+	@Column(name = "user_password", nullable = false)
+	private String password;
+
+	@Enumerated(STRING)
+	@Column(name = "user_role", nullable = false)
+	private UserRole userRole;
+
+	private User(
+		String email,
+		String name,
+		String password,
+		UserRole userRole
+	) {
+		this.email = email;
+		this.name = name;
+		this.password = password;
+		this.userRole = userRole;
+	}
+
+	public static User of(
+		String email,
+		String name,
+		String password,
+		UserRole userRole
+	) {
+		return new User(email, name, password, userRole);
+	}
 }

--- a/core/src/main/java/dev/hooon/user/domain/entity/UserMapper.java
+++ b/core/src/main/java/dev/hooon/user/domain/entity/UserMapper.java
@@ -1,0 +1,19 @@
+package dev.hooon.user.domain.entity;
+
+import static dev.hooon.user.domain.entity.UserRole.*;
+
+import dev.hooon.user.dto.request.UserJoinRequestDto;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public final class UserMapper {
+
+	public static User toBuyerUser(UserJoinRequestDto userJoinRequestDto) {
+		return User.of(
+			userJoinRequestDto.email(),
+			userJoinRequestDto.name(),
+			userJoinRequestDto.password(),
+			BUYER
+		);
+	}
+}

--- a/core/src/main/java/dev/hooon/user/domain/repository/UserRepository.java
+++ b/core/src/main/java/dev/hooon/user/domain/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package dev.hooon.user.domain.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import dev.hooon.user.domain.entity.User;
@@ -7,4 +8,7 @@ import dev.hooon.user.domain.entity.User;
 public interface UserRepository {
 
 	Optional<User> findById(Long id);
+
+	List<User> findByName(String name);
+	Long save(User user);
 }

--- a/core/src/main/java/dev/hooon/user/dto/request/UserJoinRequestDto.java
+++ b/core/src/main/java/dev/hooon/user/dto/request/UserJoinRequestDto.java
@@ -1,0 +1,14 @@
+package dev.hooon.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record UserJoinRequestDto(
+
+	@Email
+	String email,
+	@NotBlank
+	String password,
+	@NotBlank
+	String name
+) {}

--- a/core/src/main/java/dev/hooon/user/dto/response/UserJoinResponseDto.java
+++ b/core/src/main/java/dev/hooon/user/dto/response/UserJoinResponseDto.java
@@ -1,0 +1,6 @@
+package dev.hooon.user.dto.response;
+
+public record UserJoinResponseDto(
+
+	Long userId
+) {}

--- a/core/src/main/java/dev/hooon/user/exception/UserErrorCode.java
+++ b/core/src/main/java/dev/hooon/user/exception/UserErrorCode.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
 
-	NOT_FOUND_BY_ID("ID 에 해당하는 사용자가 존재하지 않습니다", "U_001");
+	NOT_FOUND_BY_ID("ID 에 해당하는 사용자가 존재하지 않습니다", "U_001"),
+	DUPLICATED_USER("이미 존재하는 회원입니다.", "U_002");
 
 	private final String message;
 	private final String code;

--- a/core/src/main/java/dev/hooon/user/exception/UserException.java
+++ b/core/src/main/java/dev/hooon/user/exception/UserException.java
@@ -1,0 +1,15 @@
+package dev.hooon.user.exception;
+
+import dev.hooon.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class UserException extends RuntimeException {
+
+	private final String code;
+
+	public UserException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.code = errorCode.getCode();
+	}
+}

--- a/core/src/main/java/dev/hooon/user/infrastructure/adaptor/UserRepositoryAdaptor.java
+++ b/core/src/main/java/dev/hooon/user/infrastructure/adaptor/UserRepositoryAdaptor.java
@@ -1,5 +1,6 @@
 package dev.hooon.user.infrastructure.adaptor;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
@@ -18,5 +19,15 @@ public class UserRepositoryAdaptor implements UserRepository {
 	@Override
 	public Optional<User> findById(Long id) {
 		return userJpaRepository.findById(id);
+	}
+
+	@Override
+	public List<User> findByName(String name) {
+		return userJpaRepository.findByName(name);
+	}
+
+	@Override
+	public Long save(User user) {
+		return userJpaRepository.save(user).getId();
 	}
 }

--- a/core/src/main/java/dev/hooon/user/infrastructure/repository/UserJpaRepository.java
+++ b/core/src/main/java/dev/hooon/user/infrastructure/repository/UserJpaRepository.java
@@ -1,8 +1,12 @@
 package dev.hooon.user.infrastructure.repository;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import dev.hooon.user.domain.entity.User;
 
 public interface UserJpaRepository extends JpaRepository<User, Long> {
+	List<User> findByName(String name);
 }


### PR DESCRIPTION
## 📄 무엇을 개발했나요? 
* 유저 엔티티 수정
* 회원가입 로직 구현

## 🍸 무엇을 집중적으로 리뷰해야할까요?
* User 엔티티의 생성자와 팩토리메서드를 만든 이유는 userMapper 에서 dto 를 엔티티로 변환하기 위함입니다~
* @PostMapping("/api/users/new") 는 Api 명세서와 다르게 만들어보았습니다. 원래 /api/auth 였는데,
   회원가입시에 인증인가는 필요없는 듯 해서 /api/users/new 가 어떨까 싶습니다.
* 그 외 어색한 부분이라든지, 리뷰 다 좋습니다