### PR TITLE
[feat] : 예매대기 등록 API Controller 구현

### DIFF
--- a/api/src/main/java/dev/hooon/waitingbooking/WaitingBookingApiController.java
+++ b/api/src/main/java/dev/hooon/waitingbooking/WaitingBookingApiController.java
@@ -1,0 +1,29 @@
+package dev.hooon.waitingbooking;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import dev.hooon.waitingbooking.application.facade.WaitingBookingFacade;
+import dev.hooon.waitingbooking.dto.request.WaitingRegisterRequest;
+import dev.hooon.waitingbooking.dto.response.WaitingRegisterResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class WaitingBookingApiController {
+
+	private final WaitingBookingFacade waitingBookingFacade;
+
+	@PostMapping("/api/waiting_bookings")
+	public ResponseEntity<WaitingRegisterResponse> registerWaitingBooking(
+		@Valid @RequestBody WaitingRegisterRequest request,
+		@RequestParam Long userId // TODO 추후에 인증정보 ArgumentResolver 가 구현되면 수정 예정
+	) {
+		WaitingRegisterResponse waitingRegisterResponse = waitingBookingFacade.registerWaitingBooking(userId, request);
+		return ResponseEntity.ok(waitingRegisterResponse);
+	}
+}

--- a/api/src/test/java/dev/hooon/common/support/ApiTestSupport.java
+++ b/api/src/test/java/dev/hooon/common/support/ApiTestSupport.java
@@ -4,9 +4,17 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
 public abstract class ApiTestSupport extends TestContainerSupport {
 
+	protected ObjectMapper objectMapper = new ObjectMapper();
+
+	protected String toJson(Object object) throws JsonProcessingException {
+		return objectMapper.writeValueAsString(object);
+	}
 }

--- a/api/src/test/java/dev/hooon/waitingbooking/WaitingBookingApiControllerTest.java
+++ b/api/src/test/java/dev/hooon/waitingbooking/WaitingBookingApiControllerTest.java
@@ -1,0 +1,66 @@
+package dev.hooon.waitingbooking;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import dev.hooon.common.support.ApiTestSupport;
+import dev.hooon.user.application.UserService;
+import dev.hooon.user.domain.entity.User;
+import dev.hooon.waitingbooking.domain.entity.WaitingBooking;
+import dev.hooon.waitingbooking.domain.repository.WaitingBookingRepository;
+import dev.hooon.waitingbooking.dto.request.WaitingRegisterRequest;
+
+@DisplayName("[WaitingBookingApiController API 테스트]")
+class WaitingBookingApiControllerTest extends ApiTestSupport {
+
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private WaitingBookingRepository waitingBookingRepository;
+	// TODO User 저장에 대한 로직을 다른 작업에서 병행중이어서 일단 모킹으로 대체하구 추후에 수정
+	@MockBean
+	private UserService userService;
+
+	@Test
+	@DisplayName("[예매대기 등록 API 를 호출하면 예매대기가 등록되고 예매대기 ID 를 응답한다]")
+	void registerWaitingBookingTest() throws Exception {
+		//given
+		// TODO 추후에 User 생성 기능이 구현되면 수정 예정
+		User user = new User();
+		ReflectionTestUtils.setField(user, "id", 1L);
+		given(userService.getUserById(1L)).willReturn(user);
+
+		WaitingRegisterRequest waitingRegisterRequest = new WaitingRegisterRequest(2, List.of(1L, 2L, 3L, 4L));
+
+		//when
+		ResultActions actions = mockMvc.perform(
+			MockMvcRequestBuilders
+				.post("/api/waiting_bookings")
+				.queryParam("userId", "1") // TODO 추후에 인증정보 ArgumentResolver 가 구현되면 수정 예정
+				.contentType(APPLICATION_JSON)
+				.content(toJson(waitingRegisterRequest))
+		);
+
+		//then
+		List<WaitingBooking> allWaitingBookings = waitingBookingRepository.findAll();
+		assertThat(allWaitingBookings).isNotEmpty();
+
+		actions.andExpectAll(
+			status().isOk(),
+			jsonPath("$.waitingBookingId").value(allWaitingBookings.get(0).getId())
+		);
+	}
+}

--- a/core/src/main/java/dev/hooon/waitingbooking/domain/repository/WaitingBookingRepository.java
+++ b/core/src/main/java/dev/hooon/waitingbooking/domain/repository/WaitingBookingRepository.java
@@ -1,8 +1,12 @@
 package dev.hooon.waitingbooking.domain.repository;
 
+import java.util.List;
+
 import dev.hooon.waitingbooking.domain.entity.WaitingBooking;
 
 public interface WaitingBookingRepository {
 
 	void save(WaitingBooking waitingBooking);
+
+	List<WaitingBooking> findAll();
 }

--- a/core/src/main/java/dev/hooon/waitingbooking/dto/request/WaitingRegisterRequest.java
+++ b/core/src/main/java/dev/hooon/waitingbooking/dto/request/WaitingRegisterRequest.java
@@ -2,8 +2,13 @@ package dev.hooon.waitingbooking.dto.request;
 
 import java.util.List;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
 public record WaitingRegisterRequest(
+	@Positive
 	int seatCount,
+	@NotNull
 	List<Long> seatIds
 ) {
 }

--- a/core/src/main/java/dev/hooon/waitingbooking/infrastructure/adaptor/WaitingBookingRepositoryAdaptor.java
+++ b/core/src/main/java/dev/hooon/waitingbooking/infrastructure/adaptor/WaitingBookingRepositoryAdaptor.java
@@ -1,5 +1,7 @@
 package dev.hooon.waitingbooking.infrastructure.adaptor;
 
+import java.util.List;
+
 import org.springframework.stereotype.Repository;
 
 import dev.hooon.waitingbooking.domain.entity.WaitingBooking;
@@ -17,4 +19,10 @@ public class WaitingBookingRepositoryAdaptor implements WaitingBookingRepository
 	public void save(WaitingBooking waitingBooking) {
 		waitingBookingJpaRepository.save(waitingBooking);
 	}
+
+	@Override
+	public List<WaitingBooking> findAll() {
+		return waitingBookingJpaRepository.findAll();
+	}
+
 }


### PR DESCRIPTION
## 📄 무엇을 개발했나요? 
* 예매대기 등록 API Controller 구현

## 🍸 무엇을 집중적으로 리뷰해야할까요?
* User 에 대한 저장로직과 인증에 대한 ArgumentResolver 가 구현되있지 않아서 임시대로 대체한 코드가 여럿 있습니다. 전부 주석과 TODO 로 표시해놨고, 승인되면 해당 주석들에 대한 작업들은 이슈로 새로 등록해놓겠습니다