### PR TITLE
[feat] : 예매대기 활성화 알림 매일발송 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 
 .DS_Store
 core/src/main/resources/application.yml
+scheduler/src/main/resources/application.yml
 
 ### STS ###
 .apt_generated

--- a/core/src/main/java/dev/hooon/show/domain/repository/SeatRepository.java
+++ b/core/src/main/java/dev/hooon/show/domain/repository/SeatRepository.java
@@ -20,5 +20,5 @@ public interface SeatRepository {
 
 	void updateStatusByIdIn(Collection<Long> ids, SeatStatus status);
 
-	String findShowNameById(Long id);
+	Optional<String> findShowNameById(Long id);
 }

--- a/core/src/main/java/dev/hooon/show/domain/repository/SeatRepository.java
+++ b/core/src/main/java/dev/hooon/show/domain/repository/SeatRepository.java
@@ -19,4 +19,6 @@ public interface SeatRepository {
 	List<Seat> findByStatusIsCanceled();
 
 	void updateStatusByIdIn(Collection<Long> ids, SeatStatus status);
+
+	String findShowNameById(Long id);
 }

--- a/core/src/main/java/dev/hooon/show/exception/ShowErrorCode.java
+++ b/core/src/main/java/dev/hooon/show/exception/ShowErrorCode.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ShowErrorCode implements ErrorCode {
 
-	SHOW_NOT_FOUND("공연을 찾을 수 없습니다.", "S_001");
+	SHOW_NOT_FOUND("공연을 찾을 수 없습니다.", "S_001"),
+	SHOW_NAME_NOT_FOUND("좌석에 해당하는 공연의 이름을 찾을 수 없습니다", "S_002");
 
 	private final String message;
 	private final String code;

--- a/core/src/main/java/dev/hooon/show/infrastructure/adaptor/SeatRepositoryAdaptor.java
+++ b/core/src/main/java/dev/hooon/show/infrastructure/adaptor/SeatRepositoryAdaptor.java
@@ -45,7 +45,7 @@ public class SeatRepositoryAdaptor implements SeatRepository {
 	}
 
 	@Override
-	public String findShowNameById(Long id) {
+	public Optional<String> findShowNameById(Long id) {
 		return seatJpaRepository.findShowNameById(id);
 	}
 }

--- a/core/src/main/java/dev/hooon/show/infrastructure/adaptor/SeatRepositoryAdaptor.java
+++ b/core/src/main/java/dev/hooon/show/infrastructure/adaptor/SeatRepositoryAdaptor.java
@@ -43,4 +43,9 @@ public class SeatRepositoryAdaptor implements SeatRepository {
 	public void updateStatusByIdIn(Collection<Long> ids, SeatStatus status) {
 		seatJpaRepository.updateStatusByIdIn(ids, status);
 	}
+
+	@Override
+	public String findShowNameById(Long id) {
+		return seatJpaRepository.findShowNameById(id);
+	}
 }

--- a/core/src/main/java/dev/hooon/show/infrastructure/repository/SeatJpaRepository.java
+++ b/core/src/main/java/dev/hooon/show/infrastructure/repository/SeatJpaRepository.java
@@ -2,6 +2,7 @@ package dev.hooon.show.infrastructure.repository;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -30,5 +31,5 @@ public interface SeatJpaRepository extends JpaRepository<Seat, Long> {
 	void updateStatusByIdIn(@Param("ids") Collection<Long> ids, @Param("status") SeatStatus status);
 
 	@Query("select show.name from Seat s left join Show show on show.id = s.show.id where s.id = :id")
-	String findShowNameById(@Param("id") Long id);
+	Optional<String> findShowNameById(@Param("id") Long id);
 }

--- a/core/src/main/java/dev/hooon/show/infrastructure/repository/SeatJpaRepository.java
+++ b/core/src/main/java/dev/hooon/show/infrastructure/repository/SeatJpaRepository.java
@@ -28,4 +28,7 @@ public interface SeatJpaRepository extends JpaRepository<Seat, Long> {
 	@Modifying
 	@Query("update Seat s SET s.seatStatus = :status where s.id in :ids")
 	void updateStatusByIdIn(@Param("ids") Collection<Long> ids, @Param("status") SeatStatus status);
+
+	@Query("select show.name from Seat s left join Show show on show.id = s.show.id where s.id = :id")
+	String findShowNameById(@Param("id") Long id);
 }

--- a/core/src/main/java/dev/hooon/waitingbooking/application/facade/WaitingBookingFacade.java
+++ b/core/src/main/java/dev/hooon/waitingbooking/application/facade/WaitingBookingFacade.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 
 import dev.hooon.show.application.SeatService;
@@ -14,6 +15,7 @@ import dev.hooon.waitingbooking.application.WaitingBookingService;
 import dev.hooon.waitingbooking.domain.entity.WaitingBooking;
 import dev.hooon.waitingbooking.dto.request.WaitingRegisterRequest;
 import dev.hooon.waitingbooking.dto.response.WaitingRegisterResponse;
+import dev.hooon.waitingbooking.event.WaitingBookingActiveEvent;
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -23,6 +25,7 @@ public class WaitingBookingFacade {
 	private final WaitingBookingService waitingBookingService;
 	private final UserService userService;
 	private final SeatService seatService;
+	private final ApplicationEventPublisher eventPublisher;
 
 	// 선택한 좌석중에서 취소좌석에 포함되는 좌석 ID 를 LIST 로 응답
 	private List<Long> fetchMatchingSeatIds(
@@ -57,27 +60,26 @@ public class WaitingBookingFacade {
 		// 2. 대기중 상태인 예약대기 목록을 날짜순으로 조회한다
 		List<WaitingBooking> waitingList = waitingBookingService.getWaitingBookingsByStatusIsWaiting();
 		// 3. waitingList 반복하면서 아래 작업을 수행
-		/*
-		 * (1) 대기목록에 포함된 좌석의 PK 가 취소된 좌석 Set 에 존재하는지 확인
-		 * (2) 대기목록의 좌석중에서 취소목록에 포함되는 좌석 아이디 가져옴
-		 * (3) 가져온 좌석 아이디 사이즈가 선택좌석개수와 같으면 취소좌석 SET 에서 해당 PK 지우고 좌석 상태를 취소에서 대기로 바꾸고 예약대기를 활성화
-		 *  + 사용자에게 메일 발송 (구현 예정)
-		 */
 		waitingList.forEach(waitingBooking -> {
-			// (1)
+			// (1) 대기목록에 포함된 좌석의 PK 가 취소된 좌석 Set 에 존재하는지 확인
 			List<Long> selectedSeatIds = waitingBooking.getSelectedSeatIds();
-			// (2)
+			// (2) 대기목록의 좌석중에서 취소목록에 포함되는 좌석 아이디 가져옴
 			List<Long> matchSeatIds = fetchMatchingSeatIds(
 				canceledSeatIds,
 				selectedSeatIds,
 				waitingBooking.getSeatCount()
 			);
-			// (3)
+			// (3) 가져온 좌석 아이디 사이즈가 선택좌석개수와 같으면 취소좌석 SET 에서 해당 PK 지우고 좌석 상태를 취소에서 대기로 바꾸고 예약대기를 활성화
 			if (matchSeatIds.size() == waitingBooking.getSeatCount()) {
 				matchSeatIds.forEach(canceledSeatIds::remove);
 				seatService.updateSeatToWaiting(matchSeatIds);
 				waitingBookingService.activateWaitingBooking(waitingBooking.getId(), matchSeatIds);
-				// 메일 알림 이벤트 발행
+				// (4) 사용자에게 메일 발송
+				eventPublisher.publishEvent(new WaitingBookingActiveEvent(
+					waitingBooking.getUser().getName(),
+					waitingBooking.getUser().getEmail(),
+					matchSeatIds.get(0))
+				);
 			}
 		});
 		// 4. 반복이 끝났는데 남아있는 취소 좌석들은 예약가능 상태로 변경

--- a/core/src/main/java/dev/hooon/waitingbooking/event/WaitingBookingActiveEvent.java
+++ b/core/src/main/java/dev/hooon/waitingbooking/event/WaitingBookingActiveEvent.java
@@ -1,0 +1,8 @@
+package dev.hooon.waitingbooking.event;
+
+public record WaitingBookingActiveEvent(
+	String nickname,
+	String email,
+	Long seatId
+) {
+}

--- a/core/src/test/java/dev/hooon/show/domain/repository/SeatRepositoryTest.java
+++ b/core/src/test/java/dev/hooon/show/domain/repository/SeatRepositoryTest.java
@@ -14,6 +14,11 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import dev.hooon.common.fixture.SeatFixture;
 import dev.hooon.common.support.DataJpaTestSupport;
+import dev.hooon.show.domain.entity.Show;
+import dev.hooon.show.domain.entity.ShowCategory;
+import dev.hooon.show.domain.entity.ShowPeriod;
+import dev.hooon.show.domain.entity.ShowTime;
+import dev.hooon.show.domain.entity.place.Place;
 import dev.hooon.show.domain.entity.seat.Seat;
 import dev.hooon.show.domain.entity.seat.SeatStatus;
 import dev.hooon.show.dto.query.SeatDateRoundDto;
@@ -25,6 +30,10 @@ class SeatRepositoryTest extends DataJpaTestSupport {
 
 	@Autowired
 	private SeatRepository seatRepository;
+	@Autowired
+	private PlaceRepository placeRepository;
+	@Autowired
+	private ShowRepository showRepository;
 	@PersistenceContext
 	private EntityManager entityManager;
 
@@ -107,5 +116,33 @@ class SeatRepositoryTest extends DataJpaTestSupport {
 		assertThat(actualIds)
 			.hasSameSizeAs(seatIds)
 			.containsAll(seatIds);
+	}
+
+	@Test
+	@DisplayName("[id 에 해당하는 좌석의 공연 이름을 조회한다]")
+	void findShowNameById_test() {
+		//given
+		Place place = new Place("placeName", null, "address", null);
+		Show show = new Show(
+			"show",
+			ShowCategory.CONCERT,
+			new ShowPeriod(LocalDate.now(), LocalDate.now().plusMonths(1)),
+			new ShowTime(100, 10),
+			"청불",
+			100,
+			place
+		);
+
+		placeRepository.save(place);
+		showRepository.save(show);
+
+		Seat seat = SeatFixture.getSeat(show);
+		seatRepository.saveAll(List.of(seat));
+
+		//when
+		String result = seatRepository.findShowNameById(seat.getId());
+
+		//then
+		assertThat(result).isEqualTo(show.getName());
 	}
 }

--- a/core/src/test/java/dev/hooon/waitingbooking/application/facade/WaitingBookingFacadeTest.java
+++ b/core/src/test/java/dev/hooon/waitingbooking/application/facade/WaitingBookingFacadeTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import dev.hooon.common.fixture.WaitingBookingFixture;
@@ -24,6 +25,7 @@ import dev.hooon.waitingbooking.application.WaitingBookingService;
 import dev.hooon.waitingbooking.domain.entity.WaitingBooking;
 import dev.hooon.waitingbooking.dto.request.WaitingRegisterRequest;
 import dev.hooon.waitingbooking.dto.response.WaitingRegisterResponse;
+import dev.hooon.waitingbooking.event.WaitingBookingActiveEvent;
 
 @DisplayName("[WaitingBookingFacade 테스트]")
 @ExtendWith(MockitoExtension.class)
@@ -37,6 +39,8 @@ class WaitingBookingFacadeTest {
 	private UserService userService;
 	@Mock
 	private SeatService seatService;
+	@Mock
+	private ApplicationEventPublisher eventPublisher;
 
 	@Test
 	@DisplayName("[사용자와 예약대기 정보를 통해 예약대기를 등록한다]")
@@ -87,6 +91,8 @@ class WaitingBookingFacadeTest {
 		verify(waitingBookingService, times(1)).activateWaitingBooking(eq(waitingBookings.get(0).getId()), anyList());
 		verify(waitingBookingService, times(1)).activateWaitingBooking(eq(waitingBookings.get(1).getId()), anyList());
 		verify(seatService, times(1)).updateSeatToAvailable(anyCollection());
+
+		verify(eventPublisher, times(2)).publishEvent(any(WaitingBookingActiveEvent.class));
 	}
 
 	@Test

--- a/core/src/testFixtures/java/dev/hooon/common/fixture/SeatFixture.java
+++ b/core/src/testFixtures/java/dev/hooon/common/fixture/SeatFixture.java
@@ -69,4 +69,20 @@ public class SeatFixture {
 		ReflectionTestUtils.setField(seat, "id", seatId);
 		return seat;
 	}
+
+	public static Seat getSeat(Show show) {
+		return Seat.of(
+			show,
+			SeatGrade.VIP,
+			true,
+			"1층",
+			"A",
+			10,
+			100000,
+			LocalDate.now(),
+			1,
+			LocalTime.now(),
+			SeatStatus.AVAILABLE
+		);
+	}
 }

--- a/scheduler/build.gradle
+++ b/scheduler/build.gradle
@@ -1,5 +1,7 @@
 dependencies {
-    testImplementation 'org.springframework:spring-tx:6.1.1'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.springframework:spring-tx:6.1.1'
 
     implementation project(':core')
     testImplementation(testFixtures(project(':core')))

--- a/scheduler/src/main/java/dev/hooon/common/config/MailConfig.java
+++ b/scheduler/src/main/java/dev/hooon/common/config/MailConfig.java
@@ -1,0 +1,15 @@
+package dev.hooon.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+public class MailConfig {
+
+	@Bean
+	public JavaMailSender javaMailSender() {
+		return new JavaMailSenderImpl();
+	}
+}

--- a/scheduler/src/main/java/dev/hooon/common/config/SchedulerConfig.java
+++ b/scheduler/src/main/java/dev/hooon/common/config/SchedulerConfig.java
@@ -1,23 +1,23 @@
 package dev.hooon.common.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.scheduling.annotation.SchedulingConfigurer;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
-import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 
 @Configuration
 @EnableScheduling
-public class SchedulerConfig implements SchedulingConfigurer {
+@EnableAsync
+public class SchedulerConfig {
 
-	@Override
-	public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
-		ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
-
-		scheduler.setPoolSize(10);
-		scheduler.setThreadNamePrefix("scheduler-thread-");
-		scheduler.initialize();
-
-		taskRegistrar.setScheduler(scheduler);
+	@Bean("scheduler")
+	public TaskScheduler taskScheduler() {
+		ThreadPoolTaskScheduler executor = new ThreadPoolTaskScheduler();
+		executor.setPoolSize(5);
+		executor.setThreadNamePrefix("scheduler-thread-");
+		executor.initialize();
+		return executor;
 	}
 }

--- a/scheduler/src/main/java/dev/hooon/mail/MailSender.java
+++ b/scheduler/src/main/java/dev/hooon/mail/MailSender.java
@@ -1,0 +1,57 @@
+package dev.hooon.mail;
+
+import java.io.UnsupportedEncodingException;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.ITemplateEngine;
+import org.thymeleaf.context.Context;
+
+import dev.hooon.mail.dto.WaitingBookingMailDto;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+
+@Component
+public class MailSender {
+
+	private static final String PERSONAL = "Hooonterpark";
+	private static final String TITLE = "[훈터파크] 예매대기 활성 알림";
+	private static final String TEMPLATE = "waitingBookingNotification";
+
+	private final String from;
+	private final JavaMailSender mailSender;
+	private final ITemplateEngine templateEngine;
+
+	public MailSender(
+		@Value("${spring.mail.username}")
+		String from,
+		JavaMailSender mailSender,
+		ITemplateEngine templateEngine
+	) {
+		this.from = from;
+		this.mailSender = mailSender;
+		this.templateEngine = templateEngine;
+	}
+
+	public void sendWaitingBookingNotificationMail(WaitingBookingMailDto mailDto)
+		throws MessagingException, UnsupportedEncodingException
+	{
+		Context context = new Context();
+		context.setVariable("nickname", mailDto.nickname());
+		context.setVariable("showName", mailDto.showName());
+
+		String htmlTemplate = templateEngine.process(TEMPLATE, context);
+
+		MimeMessage mimeMessage = mailSender.createMimeMessage();
+		MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, "UTF-8");
+		mimeMessageHelper.setTo(mailDto.email());
+		mimeMessageHelper.setFrom(new InternetAddress(from, PERSONAL));
+		mimeMessageHelper.setSubject(TITLE);
+		mimeMessageHelper.setText(htmlTemplate, true);
+
+		mailSender.send(mimeMessage);
+	}
+}

--- a/scheduler/src/main/java/dev/hooon/mail/dto/WaitingBookingMailDto.java
+++ b/scheduler/src/main/java/dev/hooon/mail/dto/WaitingBookingMailDto.java
@@ -1,0 +1,8 @@
+package dev.hooon.mail.dto;
+
+public record WaitingBookingMailDto(
+	String nickname,
+	String email,
+	String showName
+) {
+}

--- a/scheduler/src/main/java/dev/hooon/mail/event/WaitingBookingMailEventListener.java
+++ b/scheduler/src/main/java/dev/hooon/mail/event/WaitingBookingMailEventListener.java
@@ -1,0 +1,40 @@
+package dev.hooon.mail.event;
+
+import java.io.UnsupportedEncodingException;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import dev.hooon.common.exception.NotFoundException;
+import dev.hooon.mail.MailSender;
+import dev.hooon.mail.dto.WaitingBookingMailDto;
+import dev.hooon.show.domain.repository.SeatRepository;
+import dev.hooon.show.exception.ShowErrorCode;
+import dev.hooon.waitingbooking.event.WaitingBookingActiveEvent;
+import jakarta.mail.MessagingException;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class WaitingBookingMailEventListener {
+
+	private final MailSender mailSender;
+	private final SeatRepository seatRepository;
+
+	@Async("scheduler")
+	@EventListener
+	public void sendWaitingBookingMail(WaitingBookingActiveEvent event)
+		throws MessagingException, UnsupportedEncodingException
+	{
+		String showName = seatRepository.findShowNameById(event.seatId())
+			.orElseThrow(() -> new NotFoundException(ShowErrorCode.SHOW_NAME_NOT_FOUND));
+
+		WaitingBookingMailDto mailDto = new WaitingBookingMailDto(
+			event.nickname(),
+			event.email(),
+			showName
+		);
+		mailSender.sendWaitingBookingNotificationMail(mailDto);
+	}
+}

--- a/scheduler/src/main/resources/templates/waitingBookingNotification.html
+++ b/scheduler/src/main/resources/templates/waitingBookingNotification.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>hooonterpark</title>
+</head>
+<body>
+<div class="container">
+    <h1>인터파크 예매대기 알림</h1>
+    <p th:text="${nickname} 님 예약대기하신 ${showName} 에 대한 예매가 6시간 동안 가능합니다"></p>
+    <p>6시간 안에 예매하지 않을 시 해당 좌석에 대한 예매 우선권이 사라집니다</p>
+</div>
+</body>
+</html>

--- a/scheduler/src/test/java/dev/hooon/mail/MailSenderTest.java
+++ b/scheduler/src/test/java/dev/hooon/mail/MailSenderTest.java
@@ -1,0 +1,48 @@
+package dev.hooon.mail;
+
+import static org.mockito.BDDMockito.*;
+
+import java.io.UnsupportedEncodingException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.thymeleaf.ITemplateEngine;
+import org.thymeleaf.context.Context;
+
+import dev.hooon.mail.dto.WaitingBookingMailDto;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+
+@DisplayName("[MailSender 테스트]")
+class MailSenderTest {
+
+	private final MailSender mailSender;
+	private final JavaMailSender javaMailSender = Mockito.mock(JavaMailSender.class);
+	private final ITemplateEngine iTemplateEngine = Mockito.mock(ITemplateEngine.class);
+
+	public MailSenderTest() {
+		this.mailSender = new MailSender("hello123@naver.com", javaMailSender, iTemplateEngine);
+	}
+
+	@Test
+	@DisplayName("[예약대기 활성화 알림 메일을 전송한다]")
+	void sendWaitingBookingNotificationMail_test() throws MessagingException, UnsupportedEncodingException {
+		//given
+		given(iTemplateEngine.process(eq("waitingBookingNotification"), any(Context.class)))
+			.willReturn("httpTemplate");
+
+		MimeMessage mockMimeMessage = Mockito.mock(MimeMessage.class);
+		given(javaMailSender.createMimeMessage()).willReturn(mockMimeMessage);
+
+		WaitingBookingMailDto waitingBookingMailDto = new WaitingBookingMailDto("nickname", "hello123@naver.com",
+			"showName");
+
+		//when
+		mailSender.sendWaitingBookingNotificationMail(waitingBookingMailDto);
+
+		//then
+		verify(javaMailSender, times(1)).send(mockMimeMessage);
+	}
+}

--- a/scheduler/src/test/java/dev/hooon/mail/event/WaitingBookingMailEventListenerTest.java
+++ b/scheduler/src/test/java/dev/hooon/mail/event/WaitingBookingMailEventListenerTest.java
@@ -1,0 +1,71 @@
+package dev.hooon.mail.event;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import dev.hooon.common.exception.NotFoundException;
+import dev.hooon.mail.MailSender;
+import dev.hooon.mail.dto.WaitingBookingMailDto;
+import dev.hooon.show.domain.repository.SeatRepository;
+import dev.hooon.show.exception.ShowErrorCode;
+import dev.hooon.waitingbooking.event.WaitingBookingActiveEvent;
+import jakarta.mail.MessagingException;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("[WaitingBookingMailEventListener 테스트]")
+class WaitingBookingMailEventListenerTest {
+
+	@InjectMocks
+	private WaitingBookingMailEventListener listener;
+	@Mock
+	private MailSender mailSender;
+	@Mock
+	private SeatRepository seatRepository;
+
+	@Test
+	@DisplayName("[예약대기 활성화 이벤트를 수신하여 예약대기 알림 이메일을 발송한다]")
+	void sendWaitingBookingMail_test1() throws MessagingException, UnsupportedEncodingException {
+		//given
+		WaitingBookingActiveEvent event = new WaitingBookingActiveEvent("nickname", "hello123@naver.com", 1L);
+
+		String showName = "showName";
+		given(seatRepository.findShowNameById(event.seatId()))
+			.willReturn(Optional.of(showName));
+
+		//when
+		listener.sendWaitingBookingMail(event);
+
+		//then
+		WaitingBookingMailDto waitingBookingMailDto = new WaitingBookingMailDto(
+			event.nickname(),
+			event.email(),
+			showName
+		);
+		verify(mailSender, times(1)).sendWaitingBookingNotificationMail(waitingBookingMailDto);
+	}
+
+	@Test
+	@DisplayName("[좌석 id 에 해당하는 공연이름이 존재하지 않아 실패한다]")
+	void sendWaitingBookingMail_test2() {
+		//given
+		WaitingBookingActiveEvent event = new WaitingBookingActiveEvent("nickname", "hello123@naver.com", 1L);
+
+		given(seatRepository.findShowNameById(event.seatId()))
+			.willReturn(Optional.empty());
+
+		//when, then
+		assertThatThrownBy(() -> listener.sendWaitingBookingMail(event))
+			.isInstanceOf(NotFoundException.class)
+			.hasMessageContaining(ShowErrorCode.SHOW_NAME_NOT_FOUND.getMessage());
+	}
+}

--- a/scheduler/src/test/resources/application.yml
+++ b/scheduler/src/test/resources/application.yml
@@ -8,6 +8,19 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: true
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: username
+    password: password
+    protocol: smtp
+    properties:
+      mail:
+        smtp:
+          starttls:
+            enable: true
+          auth: true
+
 logging:
   level:
     org.hibernate.sql: info


### PR DESCRIPTION
## 📄 무엇을 개발했나요? 
* 메일 발송을 하는 `MailSender` 구현
* 메일 비동기 발송을 위한 비동기 설정 추가
* 예매대기 활성화 이벤트를 수신해서 메일을 발송하는 `WaitingBookingMailEventListener` 구현
## 🍸 무엇을 집중적으로 리뷰해야할까요?
* html 템플릿은 정말 간단하게 텍스트만 전달하도록 구현했습니다
* 이번 구현에는 복잡한 부분이 크게없어서 주석을 신경쓰지않았는데 궁금한점 있으시면 바로 물어봐주세요
* 머지는 직접하겠습니다~ (rebase 하고 한번에 머지할 생각입니다)