### PR TITLE
[feat]: 공연 예매 API 추가

### DIFF
--- a/api/src/main/java/dev/hooon/ticketbooking/TicketBookingApiController.java
+++ b/api/src/main/java/dev/hooon/ticketbooking/TicketBookingApiController.java
@@ -1,0 +1,29 @@
+package dev.hooon.ticketbooking;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import dev.hooon.booking.application.fascade.TicketBookingFacade;
+import dev.hooon.booking.dto.request.TicketBookingRequest;
+import dev.hooon.booking.dto.response.TicketBookingResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class TicketBookingApiController {
+
+	private final TicketBookingFacade ticketBookingFacade;
+
+	@PostMapping("/api/bookings")
+	public ResponseEntity<TicketBookingResponse> bookingTicket(
+		@RequestParam(name = "userId") Long userId, // TODO
+		@Valid @RequestBody TicketBookingRequest ticketBookingRequest
+	) {
+		TicketBookingResponse ticketBookingResponse = ticketBookingFacade.bookingTicket(userId, ticketBookingRequest);
+		return ResponseEntity.ok(ticketBookingResponse);
+	}
+}

--- a/api/src/main/java/dev/hooon/waitingbooking/WaitingBookingApiController.java
+++ b/api/src/main/java/dev/hooon/waitingbooking/WaitingBookingApiController.java
@@ -20,8 +20,8 @@ public class WaitingBookingApiController {
 
 	@PostMapping("/api/waiting_bookings")
 	public ResponseEntity<WaitingRegisterResponse> registerWaitingBooking(
-		@Valid @RequestBody WaitingRegisterRequest request,
-		@RequestParam Long userId // TODO 추후에 인증정보 ArgumentResolver 가 구현되면 수정 예정
+		@RequestParam(name = "userId") Long userId, // TODO 추후에 인증정보 ArgumentResolver 가 구현되면 수정 예정
+		@Valid @RequestBody WaitingRegisterRequest request
 	) {
 		WaitingRegisterResponse waitingRegisterResponse = waitingBookingFacade.registerWaitingBooking(userId, request);
 		return ResponseEntity.ok(waitingRegisterResponse);

--- a/api/src/test/java/dev/hooon/ticketbooking/TicketBookingApiControllerTest.java
+++ b/api/src/test/java/dev/hooon/ticketbooking/TicketBookingApiControllerTest.java
@@ -1,0 +1,88 @@
+package dev.hooon.ticketbooking;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import dev.hooon.booking.dto.request.TicketBookingRequest;
+import dev.hooon.common.support.ApiTestSupport;
+import dev.hooon.user.application.UserService;
+import dev.hooon.user.domain.entity.User;
+
+@DisplayName("[TicketBookingApiController API 테스트]")
+@Sql("/sql/booking_dummy.sql")
+class TicketBookingApiControllerTest extends ApiTestSupport {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private UserService userService;
+
+	@DisplayName("사용자는 티켓을 예매할 수 있다")
+	@Test
+	void bookingTicketTest() throws Exception {
+
+		// given
+		TicketBookingRequest ticketBookingRequest = new TicketBookingRequest(List.of(1L, 2L, 3L));
+		User user = new User();
+		ReflectionTestUtils.setField(user, "id", 1L);
+		given(userService.getUserById(1L)).willReturn(user);
+
+		// when
+		ResultActions resultActions = mockMvc.perform(
+			MockMvcRequestBuilders
+				.post("/api/bookings")
+				.queryParam("userId", "1") // TODO: 인증 구현되면 수정할 것
+				.accept(APPLICATION_JSON)
+				.contentType(APPLICATION_JSON)
+				.content(toJson(ticketBookingRequest))
+		);
+
+		// then
+		resultActions.andExpectAll(
+			status().isOk(),
+
+			jsonPath("$.bookingTickets").isArray(),
+
+			jsonPath("$.bookingTickets[0].ticketId").isNumber(),
+			jsonPath("$.bookingTickets[0].showName").isString(),
+			jsonPath("$.bookingTickets[0].seatGrade").isString(),
+			jsonPath("$.bookingTickets[0].seatPositionInfo").isString(),
+			jsonPath("$.bookingTickets[0].seatStatus").value("BOOKED"),
+			jsonPath("$.bookingTickets[0].showDate").isString(),
+			jsonPath("$.bookingTickets[0].showTime").isString(),
+			jsonPath("$.bookingTickets[0].showRound").isNumber(),
+
+			jsonPath("$.bookingTickets[1].ticketId").isNumber(),
+			jsonPath("$.bookingTickets[1].showName").isString(),
+			jsonPath("$.bookingTickets[1].seatGrade").isString(),
+			jsonPath("$.bookingTickets[1].seatPositionInfo").isString(),
+			jsonPath("$.bookingTickets[1].seatStatus").value("BOOKED"),
+			jsonPath("$.bookingTickets[1].showDate").isString(),
+			jsonPath("$.bookingTickets[1].showTime").isString(),
+			jsonPath("$.bookingTickets[1].showRound").isNumber(),
+
+			jsonPath("$.bookingTickets[2].ticketId").isNumber(),
+			jsonPath("$.bookingTickets[2].showName").isString(),
+			jsonPath("$.bookingTickets[2].seatGrade").isString(),
+			jsonPath("$.bookingTickets[2].seatPositionInfo").isString(),
+			jsonPath("$.bookingTickets[2].seatStatus").value("BOOKED"),
+			jsonPath("$.bookingTickets[2].showDate").isString(),
+			jsonPath("$.bookingTickets[2].showTime").isString(),
+			jsonPath("$.bookingTickets[2].showRound").isNumber()
+		);
+	}
+}

--- a/core/src/main/java/dev/hooon/booking/application/BookingService.java
+++ b/core/src/main/java/dev/hooon/booking/application/BookingService.java
@@ -1,0 +1,18 @@
+package dev.hooon.booking.application;
+
+import org.springframework.stereotype.Service;
+
+import dev.hooon.booking.domain.entity.Booking;
+import dev.hooon.booking.domain.repository.BookingRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class BookingService {
+
+	private final BookingRepository bookingRepository;
+
+	public Booking bookingTicket(Booking booking) {
+		return bookingRepository.save(booking);
+	}
+}

--- a/core/src/main/java/dev/hooon/booking/application/fascade/TicketBookingFacade.java
+++ b/core/src/main/java/dev/hooon/booking/application/fascade/TicketBookingFacade.java
@@ -29,7 +29,7 @@ public class TicketBookingFacade {
 	private final SeatService seatService;
 	private final UserService userService;
 
-	private void validateAvailableSeat(Seat seat) {
+	private static void validateAvailableSeat(Seat seat) {
 		if (!seat.isBookingAvailable()) {
 			throw new ValidationException(NOT_AVAILABLE_SEAT);
 		}

--- a/core/src/main/java/dev/hooon/booking/application/fascade/TicketBookingFacade.java
+++ b/core/src/main/java/dev/hooon/booking/application/fascade/TicketBookingFacade.java
@@ -50,12 +50,12 @@ public class TicketBookingFacade {
 		seatList.forEach(TicketBookingFacade::validateAvailableSeat);
 
 		// 예매 생성
-		Booking booking = new Booking(user, show);
+		Booking booking = Booking.of(user, show);
 
 		// 예매에 티켓리스트 넣기
 		seatList.forEach(seat -> {
 			seat.markSeatStatusAsBooked();
-			booking.addTicket(new Ticket(seat));
+			booking.addTicket(Ticket.of(seat));
 		});
 
 		// 예매 저장

--- a/core/src/main/java/dev/hooon/booking/application/fascade/TicketBookingFacade.java
+++ b/core/src/main/java/dev/hooon/booking/application/fascade/TicketBookingFacade.java
@@ -29,13 +29,13 @@ public class TicketBookingFacade {
 	private final SeatService seatService;
 	private final UserService userService;
 
-	private static void validateAvailableSeat(Seat seat) {
+	private void validateAvailableSeat(Seat seat) {
 		if (!seat.isBookingAvailable()) {
 			throw new ValidationException(NOT_AVAILABLE_SEAT);
 		}
 	}
 
-	private static void validateSeatList(int seatIdsSize, List<Seat> seatList) {
+	private void validateSeatList(int seatIdsSize, List<Seat> seatList) {
 		if (seatList.isEmpty()) {
 			throw new ValidationException(INVALID_EMPTY_SEAT);
 		}

--- a/core/src/main/java/dev/hooon/booking/application/fascade/TicketBookingFacade.java
+++ b/core/src/main/java/dev/hooon/booking/application/fascade/TicketBookingFacade.java
@@ -1,0 +1,81 @@
+package dev.hooon.booking.application.fascade;
+
+import static dev.hooon.booking.exception.BookingErrorCode.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import dev.hooon.booking.application.BookingService;
+import dev.hooon.booking.domain.entity.Booking;
+import dev.hooon.booking.domain.entity.Ticket;
+import dev.hooon.booking.dto.BookingMapper;
+import dev.hooon.booking.dto.request.TicketBookingRequest;
+import dev.hooon.booking.dto.response.TicketBookingResponse;
+import dev.hooon.common.exception.ValidationException;
+import dev.hooon.show.application.SeatService;
+import dev.hooon.show.domain.entity.Show;
+import dev.hooon.show.domain.entity.seat.Seat;
+import dev.hooon.user.application.UserService;
+import dev.hooon.user.domain.entity.User;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class TicketBookingFacade {
+
+	private final BookingService bookingService;
+	private final SeatService seatService;
+	private final UserService userService;
+
+	@Transactional
+	public TicketBookingResponse bookingTicket(
+		Long userId,
+		TicketBookingRequest ticketBookingRequest
+	) {
+
+		// 유저서비스에서 [유저] 가져옴
+		User user = userService.getUserById(userId);
+
+		// 좌석서비스에서 [모든 좌석들] 가져옴
+		List<Seat> seatList = seatService.findByIdIn(ticketBookingRequest.seatIds());
+		// 가져온 [모든 좌석들] validation
+		validateSeatList(ticketBookingRequest.seatIds().size(), seatList);
+
+		// 좌석에서 [공연] 가져옴
+		Show show = seatList.get(0).getShow();
+
+		// 모든 좌석들에 대해 [각 좌석] validation
+		seatList.forEach(TicketBookingFacade::validateAvailableSeat);
+
+		// 예매 생성
+		Booking booking = new Booking(user, show);
+
+		// 예매에 티켓리스트 넣기
+		seatList.forEach(seat -> {
+			seat.markSeatStatusAsBooked();
+			booking.addTicket(new Ticket(seat));
+		});
+
+		// 예매 저장
+		Booking savedbooking = bookingService.bookingTicket(booking);
+
+		return BookingMapper.toTicketBookingResponse(savedbooking);
+	}
+
+	private static void validateAvailableSeat(Seat seat) {
+		if (!seat.isBookingAvailable()) {
+			throw new ValidationException(NOT_AVAILABLE_SEAT);
+		}
+	}
+
+	private static void validateSeatList(int seatIdsSize, List<Seat> seatList) {
+		if (seatList.isEmpty()) {
+			throw new ValidationException(INVALID_EMPTY_SEAT);
+		}
+		if (seatList.size() != seatIdsSize) {
+			throw new ValidationException(INVALID_SELECTED_SEAT);
+		}
+	}
+}

--- a/core/src/main/java/dev/hooon/booking/application/fascade/TicketBookingFacade.java
+++ b/core/src/main/java/dev/hooon/booking/application/fascade/TicketBookingFacade.java
@@ -29,6 +29,21 @@ public class TicketBookingFacade {
 	private final SeatService seatService;
 	private final UserService userService;
 
+	private static void validateAvailableSeat(Seat seat) {
+		if (!seat.isBookingAvailable()) {
+			throw new ValidationException(NOT_AVAILABLE_SEAT);
+		}
+	}
+
+	private static void validateSeatList(int seatIdsSize, List<Seat> seatList) {
+		if (seatList.isEmpty()) {
+			throw new ValidationException(INVALID_EMPTY_SEAT);
+		}
+		if (seatList.size() != seatIdsSize) {
+			throw new ValidationException(INVALID_SELECTED_SEAT);
+		}
+	}
+
 	@Transactional
 	public TicketBookingResponse bookingTicket(
 		Long userId,
@@ -62,20 +77,5 @@ public class TicketBookingFacade {
 		Booking savedbooking = bookingService.bookingTicket(booking);
 
 		return BookingMapper.toTicketBookingResponse(savedbooking);
-	}
-
-	private static void validateAvailableSeat(Seat seat) {
-		if (!seat.isBookingAvailable()) {
-			throw new ValidationException(NOT_AVAILABLE_SEAT);
-		}
-	}
-
-	private static void validateSeatList(int seatIdsSize, List<Seat> seatList) {
-		if (seatList.isEmpty()) {
-			throw new ValidationException(INVALID_EMPTY_SEAT);
-		}
-		if (seatList.size() != seatIdsSize) {
-			throw new ValidationException(INVALID_SELECTED_SEAT);
-		}
 	}
 }

--- a/core/src/main/java/dev/hooon/booking/domain/entity/Booking.java
+++ b/core/src/main/java/dev/hooon/booking/domain/entity/Booking.java
@@ -1,14 +1,19 @@
 package dev.hooon.booking.domain.entity;
 
+import static dev.hooon.booking.domain.entity.BookingStatus.*;
 import static jakarta.persistence.ConstraintMode.*;
 import static jakarta.persistence.EnumType.*;
 import static jakarta.persistence.FetchType.*;
 import static jakarta.persistence.GenerationType.*;
 import static lombok.AccessLevel.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import dev.hooon.common.entity.TimeBaseEntity;
 import dev.hooon.show.domain.entity.Show;
 import dev.hooon.user.domain.entity.User;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;
@@ -17,6 +22,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -27,20 +33,41 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PROTECTED)
 public class Booking extends TimeBaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = IDENTITY)
-    @Column(name = "booking_id")
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	@Column(name = "booking_id")
+	private Long id;
 
-    @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "booking_user_id", nullable = false, foreignKey = @ForeignKey(value = NO_CONSTRAINT))
-    private User user;
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "booking_user_id", nullable = false, foreignKey = @ForeignKey(value = NO_CONSTRAINT))
+	private User user;
 
-    @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "booking_show_id", nullable = false, foreignKey = @ForeignKey(value = NO_CONSTRAINT))
-    private Show show;
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "booking_show_id", nullable = false, foreignKey = @ForeignKey(value = NO_CONSTRAINT))
+	private Show show;
 
-    @Enumerated(STRING)
-    @Column(name = "booking_status", nullable = false)
-    private BookingStatus bookingStatus;
+	@OneToMany(mappedBy = "booking", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Ticket> tickets = new ArrayList<>();
+
+	@Enumerated(STRING)
+	@Column(name = "booking_status", nullable = false)
+	private BookingStatus bookingStatus;
+
+	public void addTicket(Ticket ticket) {
+		tickets.add(ticket);
+		ticket.setBooking(this);
+	}
+
+	private Booking(User user, Show show) {
+		this.user = user;
+		this.show = show;
+		this.bookingStatus = BOOKED;
+	}
+
+	public static Booking of(
+		User user,
+		Show show
+	) {
+		return new Booking(user, show);
+	}
 }

--- a/core/src/main/java/dev/hooon/booking/domain/entity/Ticket.java
+++ b/core/src/main/java/dev/hooon/booking/domain/entity/Ticket.java
@@ -37,8 +37,14 @@ public class Ticket extends TimeBaseEntity {
 	@JoinColumn(name = "booking_id")
 	private Booking booking;
 
-	public Ticket(Seat seat) {
+	private Ticket(Seat seat) {
 		this.seat = seat;
+	}
+
+	public static Ticket of(
+		Seat seat
+	) {
+		return new Ticket(seat);
 	}
 
 	public void setBooking(Booking booking) {

--- a/core/src/main/java/dev/hooon/booking/domain/entity/Ticket.java
+++ b/core/src/main/java/dev/hooon/booking/domain/entity/Ticket.java
@@ -24,16 +24,24 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PROTECTED)
 public class Ticket extends TimeBaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = IDENTITY)
-    @Column(name = "ticket_id")
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	@Column(name = "ticket_id")
+	private Long id;
 
-    @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "ticket_booking_id", nullable = false, foreignKey = @ForeignKey(value = NO_CONSTRAINT))
-    private Booking booking;
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "ticket_seat_id", nullable = false, foreignKey = @ForeignKey(value = NO_CONSTRAINT))
+	private Seat seat;
 
-    @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "ticket_seat_id", nullable = false, foreignKey = @ForeignKey(value = NO_CONSTRAINT))
-    private Seat seat;
+	@ManyToOne
+	@JoinColumn(name = "booking_id")
+	private Booking booking;
+
+	public Ticket(Seat seat) {
+		this.seat = seat;
+	}
+
+	public void setBooking(Booking booking) {
+		this.booking = booking;
+	}
 }

--- a/core/src/main/java/dev/hooon/booking/domain/repository/BookingRepository.java
+++ b/core/src/main/java/dev/hooon/booking/domain/repository/BookingRepository.java
@@ -1,0 +1,12 @@
+package dev.hooon.booking.domain.repository;
+
+import java.util.List;
+
+import dev.hooon.booking.domain.entity.Booking;
+
+public interface BookingRepository {
+
+	Booking save(Booking booking);
+
+	List<Booking> findAll();
+}

--- a/core/src/main/java/dev/hooon/booking/dto/BookingMapper.java
+++ b/core/src/main/java/dev/hooon/booking/dto/BookingMapper.java
@@ -1,0 +1,31 @@
+package dev.hooon.booking.dto;
+
+import java.util.List;
+
+import dev.hooon.booking.domain.entity.Booking;
+import dev.hooon.booking.dto.response.TicketBookingResponse;
+import dev.hooon.booking.dto.response.TicketResponse;
+import dev.hooon.show.domain.entity.Show;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class BookingMapper {
+
+	public static TicketBookingResponse toTicketBookingResponse(Booking booking) {
+		Show show = booking.getShow();
+		List<TicketResponse> ticketResponseList = booking.getTickets().stream()
+			.map(ticket -> new TicketResponse(
+				ticket.getId(),
+				show.getName(),
+				ticket.getSeat().getSeatGrade().toString(),
+				ticket.getSeat().getPositionInfo().toString(),
+				ticket.getSeat().getSeatStatus().toString(),
+				ticket.getSeat().getShowDate(),
+				ticket.getSeat().getStartTime(),
+				ticket.getSeat().getRound()
+			))
+			.toList();
+		return new TicketBookingResponse(ticketResponseList);
+	}
+}

--- a/core/src/main/java/dev/hooon/booking/dto/request/TicketBookingRequest.java
+++ b/core/src/main/java/dev/hooon/booking/dto/request/TicketBookingRequest.java
@@ -1,0 +1,11 @@
+package dev.hooon.booking.dto.request;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotNull;
+
+public record TicketBookingRequest(
+	@NotNull
+	List<Long> seatIds
+) {
+}

--- a/core/src/main/java/dev/hooon/booking/dto/response/TicketBookingResponse.java
+++ b/core/src/main/java/dev/hooon/booking/dto/response/TicketBookingResponse.java
@@ -1,0 +1,8 @@
+package dev.hooon.booking.dto.response;
+
+import java.util.List;
+
+public record TicketBookingResponse(
+	List<TicketResponse> bookingTickets
+) {
+}

--- a/core/src/main/java/dev/hooon/booking/dto/response/TicketResponse.java
+++ b/core/src/main/java/dev/hooon/booking/dto/response/TicketResponse.java
@@ -1,0 +1,40 @@
+package dev.hooon.booking.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+public record TicketResponse(
+	Long ticketId,
+	String showName,
+	String seatGrade,
+	String seatPositionInfo,
+	String seatStatus,
+	@JsonFormat(pattern = "yyyy-MM-dd")
+	LocalDate showDate,
+
+	@JsonFormat(pattern = "HH:mm:ss")
+	LocalTime showTime,
+	int showRound
+) {
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		TicketResponse that = (TicketResponse)o;
+		return showRound == that.showRound && Objects.equals(showName, that.showName) && Objects.equals(
+			seatGrade, that.seatGrade) && Objects.equals(seatPositionInfo, that.seatPositionInfo)
+			&& Objects.equals(seatStatus, that.seatStatus) && Objects.equals(showDate, that.showDate)
+			&& Objects.equals(showTime, that.showTime);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(showName, seatGrade, seatPositionInfo, seatStatus, showDate, showTime, showRound);
+	}
+}

--- a/core/src/main/java/dev/hooon/booking/exception/BookingErrorCode.java
+++ b/core/src/main/java/dev/hooon/booking/exception/BookingErrorCode.java
@@ -1,0 +1,17 @@
+package dev.hooon.booking.exception;
+
+import dev.hooon.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BookingErrorCode implements ErrorCode {
+
+	INVALID_EMPTY_SEAT("좌석이 선택되지 않았습니다", "B_001"),
+	INVALID_SELECTED_SEAT("선택한 좌석값들 중 유효하지 않은 좌석값이 있습니다", "B_002"),
+	NOT_AVAILABLE_SEAT("좌석 중 예매가 불가능한 좌석이 있습니다", "B_003");
+
+	private final String message;
+	private final String code;
+}

--- a/core/src/main/java/dev/hooon/booking/infrastructure/adaptor/BookingRepositoryAdaptor.java
+++ b/core/src/main/java/dev/hooon/booking/infrastructure/adaptor/BookingRepositoryAdaptor.java
@@ -1,0 +1,27 @@
+package dev.hooon.booking.infrastructure.adaptor;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import dev.hooon.booking.domain.entity.Booking;
+import dev.hooon.booking.domain.repository.BookingRepository;
+import dev.hooon.booking.infrastructure.repository.BookingJpaRepository;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class BookingRepositoryAdaptor implements BookingRepository {
+
+	private final BookingJpaRepository bookingJpaRepository;
+
+	@Override
+	public Booking save(Booking booking) {
+		return bookingJpaRepository.save(booking);
+	}
+
+	@Override
+	public List<Booking> findAll() {
+		return bookingJpaRepository.findAll();
+	}
+}

--- a/core/src/main/java/dev/hooon/booking/infrastructure/repository/BookingJpaRepository.java
+++ b/core/src/main/java/dev/hooon/booking/infrastructure/repository/BookingJpaRepository.java
@@ -1,0 +1,8 @@
+package dev.hooon.booking.infrastructure.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import dev.hooon.booking.domain.entity.Booking;
+
+public interface BookingJpaRepository extends JpaRepository<Booking, Long> {
+}

--- a/core/src/main/java/dev/hooon/show/application/SeatService.java
+++ b/core/src/main/java/dev/hooon/show/application/SeatService.java
@@ -1,6 +1,7 @@
 package dev.hooon.show.application;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -36,5 +37,9 @@ public class SeatService {
 	@Transactional
 	public void updateSeatToAvailable(Collection<Long> targetIds) {
 		seatRepository.updateStatusByIdIn(targetIds, SeatStatus.AVAILABLE);
+	}
+
+	public List<Seat> findByIdIn(List<Long> idList) {
+		return seatRepository.findByIdIn(idList);
 	}
 }

--- a/core/src/main/java/dev/hooon/show/domain/entity/seat/Seat.java
+++ b/core/src/main/java/dev/hooon/show/domain/entity/seat/Seat.java
@@ -1,6 +1,7 @@
 package dev.hooon.show.domain.entity.seat;
 
 import static dev.hooon.common.exception.CommonValidationError.*;
+import static dev.hooon.show.domain.entity.seat.SeatStatus.*;
 import static jakarta.persistence.ConstraintMode.*;
 import static jakarta.persistence.EnumType.*;
 import static jakarta.persistence.FetchType.*;
@@ -122,6 +123,14 @@ public class Seat extends TimeBaseEntity {
 		return showRound.getStartTime();
 	}
 
+	public boolean isBookingAvailable() {
+		return (isSeat) && (seatStatus == SeatStatus.AVAILABLE);
+	}
+
+	public void markSeatStatusAsBooked() {
+		this.seatStatus = BOOKED;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o)
@@ -129,14 +138,14 @@ public class Seat extends TimeBaseEntity {
 		if (o == null || getClass() != o.getClass())
 			return false;
 		Seat seat = (Seat)o;
-		return isSeat == seat.isSeat && price == seat.price && Objects.equals(id, seat.id)
-			&& Objects.equals(show, seat.show) && seatGrade == seat.seatGrade && Objects.equals(
-			positionInfo, seat.positionInfo) && Objects.equals(showDate, seat.showDate)
-			&& Objects.equals(showRound, seat.showRound) && seatStatus == seat.seatStatus;
+		return isSeat == seat.isSeat && price == seat.price && Objects.equals(show, seat.show)
+			&& seatGrade == seat.seatGrade && Objects.equals(positionInfo, seat.positionInfo)
+			&& Objects.equals(showDate, seat.showDate) && Objects.equals(showRound, seat.showRound)
+			&& seatStatus == seat.seatStatus;
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(id, show, seatGrade, isSeat, positionInfo, price, showDate, showRound, seatStatus);
+		return Objects.hash(show, seatGrade, isSeat, positionInfo, price, showDate, showRound, seatStatus);
 	}
 }

--- a/core/src/main/java/dev/hooon/show/domain/entity/seat/SeatPositionInfo.java
+++ b/core/src/main/java/dev/hooon/show/domain/entity/seat/SeatPositionInfo.java
@@ -14,22 +14,27 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PROTECTED)
 public class SeatPositionInfo {
 
-    @Column(name = "seat_sector")
-    private String sector;
+	@Column(name = "seat_sector")
+	private String sector;
 
-    @Column(name = "seat_row", nullable = false)
-    private String row;
+	@Column(name = "seat_row", nullable = false)
+	private String row;
 
-    @Column(name = "seat_col", nullable = false)
-    private int col;
+	@Column(name = "seat_col", nullable = false)
+	private int col;
 
-    public SeatPositionInfo(
-        String sector,
-        String row,
-        int col
-    ) {
-        this.sector = sector;
-        this.row = row;
-        this.col = col;
-    }
+	public SeatPositionInfo(
+		String sector,
+		String row,
+		int col
+	) {
+		this.sector = sector;
+		this.row = row;
+		this.col = col;
+	}
+
+	@Override
+	public String toString() {
+		return sector + " " + row + "열 " + col + "행";
+	}
 }

--- a/core/src/main/java/dev/hooon/show/domain/repository/SeatRepository.java
+++ b/core/src/main/java/dev/hooon/show/domain/repository/SeatRepository.java
@@ -14,7 +14,7 @@ import dev.hooon.show.dto.query.seats.SeatsInfoDto;
 
 public interface SeatRepository {
 
-	void saveAll(Iterable<Seat> seats);
+	List<Seat> saveAll(Iterable<Seat> seats);
 
 	Optional<Seat> findById(Long id);
 
@@ -38,4 +38,6 @@ public interface SeatRepository {
 		int round,
 		SeatGrade grade
 	);
+
+	List<Seat> findByIdIn(List<Long> idList);
 }

--- a/core/src/main/java/dev/hooon/show/infrastructure/adaptor/SeatRepositoryAdaptor.java
+++ b/core/src/main/java/dev/hooon/show/infrastructure/adaptor/SeatRepositoryAdaptor.java
@@ -24,8 +24,8 @@ public class SeatRepositoryAdaptor implements SeatRepository {
 	private final SeatJpaRepository seatJpaRepository;
 
 	@Override
-	public void saveAll(Iterable<Seat> seats) {
-		seatJpaRepository.saveAll(seats);
+	public List<Seat> saveAll(Iterable<Seat> seats) {
+		return seatJpaRepository.saveAll(seats);
 	}
 
 	@Override
@@ -64,5 +64,10 @@ public class SeatRepositoryAdaptor implements SeatRepository {
 		Long showId, LocalDate date, int round, SeatGrade grade
 	) {
 		return seatJpaRepository.findSeatsByShowIdAndDateAndRoundAndGrade(showId, date, round, grade);
+	}
+
+	@Override
+	public List<Seat> findByIdIn(List<Long> idList) {
+		return seatJpaRepository.findByIdIn(idList);
 	}
 }

--- a/core/src/main/java/dev/hooon/show/infrastructure/repository/SeatJpaRepository.java
+++ b/core/src/main/java/dev/hooon/show/infrastructure/repository/SeatJpaRepository.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,6 +18,7 @@ import dev.hooon.show.domain.entity.seat.SeatStatus;
 import dev.hooon.show.dto.query.SeatDateRoundDto;
 import dev.hooon.show.dto.query.seats.SeatsDetailDto;
 import dev.hooon.show.dto.query.seats.SeatsInfoDto;
+import jakarta.persistence.LockModeType;
 
 public interface SeatJpaRepository extends JpaRepository<Seat, Long> {
 
@@ -64,4 +66,7 @@ public interface SeatJpaRepository extends JpaRepository<Seat, Long> {
 		@Param("round") int round,
 		@Param("grade") SeatGrade grade
 	);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	List<Seat> findByIdIn(List<Long> idList);
 }

--- a/core/src/test/java/dev/hooon/booking/application/fascade/TicketBookingFacadeIntegrationTest.java
+++ b/core/src/test/java/dev/hooon/booking/application/fascade/TicketBookingFacadeIntegrationTest.java
@@ -219,6 +219,13 @@ class TicketBookingFacadeIntegrationTest extends TestContainerSupport {
 		assertEquals(2, bookingList.size());
 	}
 
+	/**
+	 * 동시에 같은 좌석들을 예매하는 다중 스레드를 요청합니다
+	 *
+	 * @param user
+	 * @param idList
+	 * @return
+	 */
 	private List<Callable<TicketBookingResponse>> getCallables1(User user, List<Long> idList) {
 		List<Callable<TicketBookingResponse>> callables = new ArrayList<>();
 		for (int i = 0; i < 100; i++) {
@@ -227,6 +234,13 @@ class TicketBookingFacadeIntegrationTest extends TestContainerSupport {
 		return callables;
 	}
 
+	/**
+	 * 겹치는 좌석들을 예매하는 다중 스레드를 요청합니다
+	 *
+	 * @param user
+	 * @param idList
+	 * @return
+	 */
 	private List<Callable<TicketBookingResponse>> getCallables2(User user, List<Long> idList) {
 		List<Callable<TicketBookingResponse>> callables = new ArrayList<>();
 		callables.add(

--- a/core/src/test/java/dev/hooon/booking/application/fascade/TicketBookingFacadeIntegrationTest.java
+++ b/core/src/test/java/dev/hooon/booking/application/fascade/TicketBookingFacadeIntegrationTest.java
@@ -1,0 +1,238 @@
+package dev.hooon.booking.application.fascade;
+
+import static dev.hooon.booking.exception.BookingErrorCode.*;
+import static dev.hooon.user.domain.entity.UserRole.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import dev.hooon.booking.domain.entity.Booking;
+import dev.hooon.booking.dto.request.TicketBookingRequest;
+import dev.hooon.booking.dto.response.TicketBookingResponse;
+import dev.hooon.booking.infrastructure.repository.BookingJpaRepository;
+import dev.hooon.common.exception.ValidationException;
+import dev.hooon.common.fixture.TestFixture;
+import dev.hooon.common.support.TestContainerSupport;
+import dev.hooon.show.domain.entity.Show;
+import dev.hooon.show.domain.entity.place.Place;
+import dev.hooon.show.domain.entity.seat.Seat;
+import dev.hooon.show.infrastructure.repository.PlaceJpaRepository;
+import dev.hooon.show.infrastructure.repository.SeatJpaRepository;
+import dev.hooon.show.infrastructure.repository.ShowJpaRepository;
+import dev.hooon.user.domain.entity.User;
+import dev.hooon.user.infrastructure.repository.UserJpaRepository;
+
+@DisplayName("[TicketBookingFacade 통합 테스트]")
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = NONE)
+class TicketBookingFacadeIntegrationTest extends TestContainerSupport {
+
+	@Autowired
+	private TicketBookingFacade ticketBookingFacade;
+
+	@Autowired
+	private SeatJpaRepository seatRepository;
+
+	@Autowired
+	private ShowJpaRepository showRepository;
+
+	@Autowired
+	private UserJpaRepository userRepository;
+
+	@Autowired
+	private PlaceJpaRepository placeRepository;
+
+	@Autowired
+	private BookingJpaRepository bookingRepository;
+
+	@AfterEach
+	void databaseCleanUp() {
+		bookingRepository.deleteAll();
+		placeRepository.deleteAll();
+		userRepository.deleteAll();
+		showRepository.deleteAll();
+		seatRepository.deleteAll();
+	}
+
+	@DisplayName("좌석 예매 성공 시, 예매된 모든 좌석의 seatStatus는 'BOOKED' 가 된다")
+	@Test
+	void bookingTicket_success_test() {
+
+		// given
+		User user = new User("user@email.com", "user", BUYER);
+		userRepository.save(user);
+
+		Place place = TestFixture.getPlace();
+		placeRepository.save(place);
+
+		Show show = TestFixture.getShow(place);
+		showRepository.save(show);
+
+		List<Seat> seats = TestFixture.getSeatList(show, show.getShowPeriod().getStartDate(), 1);
+		List<Seat> savedSeats = seatRepository.saveAll(seats);
+		List<Long> idList = savedSeats.stream()
+			.map(Seat::getId)
+			.toList();
+
+		// when
+		TicketBookingResponse ticketBookingResponse = ticketBookingFacade.bookingTicket(user.getId(),
+			new TicketBookingRequest(idList));
+
+		// then
+		assertThat(ticketBookingResponse.bookingTickets()).hasSize(5);
+		ticketBookingResponse.bookingTickets().forEach(
+			it -> assertEquals("BOOKED", it.seatStatus())
+		);
+	}
+
+	@DisplayName("이미 예약이 되어있는 좌석이 포함된 경우 예매 전체가 취소된다")
+	@Test
+	void bookingTicket_fail_test_1() {
+
+		// given
+		User user = new User("user@email.com", "user", BUYER);
+		userRepository.save(user);
+
+		Place place = TestFixture.getPlace();
+		placeRepository.save(place);
+
+		Show show = TestFixture.getShow(place);
+		showRepository.save(show);
+
+		List<Seat> seats = TestFixture.getReservedSeats(show, show.getShowPeriod().getStartDate(), 1);
+		List<Seat> savedSeats = seatRepository.saveAll(seats);
+		List<Long> idList = savedSeats.stream()
+			.map(Seat::getId)
+			.toList();
+
+		// when, then
+		assertThrows(
+			ValidationException.class,
+			() -> ticketBookingFacade.bookingTicket(user.getId(), new TicketBookingRequest(idList)),
+			NOT_AVAILABLE_SEAT.getMessage()
+		);
+	}
+
+	@DisplayName("유효하지 않은 좌석이 포함된 경우 예매 전체가 취소된다")
+	@Test
+	void bookingTicket_fail_test_2() {
+
+		// given
+		User user = new User("user@email.com", "user", BUYER);
+		userRepository.save(user);
+
+		Place place = TestFixture.getPlace();
+		placeRepository.save(place);
+
+		Show show = TestFixture.getShow(place);
+		showRepository.save(show);
+
+		List<Seat> seats = TestFixture.getNonValidSeats(show, show.getShowPeriod().getStartDate(), 1);
+		List<Seat> savedSeats = seatRepository.saveAll(seats);
+		List<Long> idList = savedSeats.stream()
+			.map(Seat::getId)
+			.toList();
+
+		// when, then
+		assertThrows(
+			ValidationException.class,
+			() -> ticketBookingFacade.bookingTicket(user.getId(), new TicketBookingRequest(idList)),
+			INVALID_SELECTED_SEAT.getMessage()
+		);
+	}
+
+	@DisplayName("동시에 같은 좌석들을 예매할 때 예매는 1건만 만들어진다")
+	@Test
+	void bookingTicket_concurrency_test_1() throws InterruptedException {
+
+		// given
+		ExecutorService executorService = Executors.newFixedThreadPool(100);
+
+		User user = new User("user@email.com", "user", BUYER);
+		userRepository.save(user);
+
+		Place place = TestFixture.getPlace();
+		placeRepository.save(place);
+
+		Show show = TestFixture.getShow(place);
+		showRepository.save(show);
+
+		List<Seat> seats = TestFixture.getSeatList(show, show.getShowPeriod().getStartDate(), 1);
+		List<Seat> savedSeats = seatRepository.saveAll(seats);
+		List<Long> idList = savedSeats.stream()
+			.map(Seat::getId)
+			.toList();
+
+		// when
+		executorService.invokeAll(getCallables1(user, idList));
+
+		// then
+		List<Booking> bookingList = bookingRepository.findAll();
+		assertEquals(1, bookingList.size());
+	}
+
+	@DisplayName("동시에 여러 예매가 진행될 때, 겹치는 좌석이 있으면 예매는 그 중 한 건만 만들어진다")
+	@Test
+	void bookingTicket_concurrency_test_2() throws InterruptedException {
+
+		// given
+		ExecutorService executorService = Executors.newFixedThreadPool(3);
+
+		User user = new User("user@email.com", "user", BUYER);
+		userRepository.save(user);
+
+		Place place = TestFixture.getPlace();
+		placeRepository.save(place);
+
+		Show show = TestFixture.getShow(place);
+		showRepository.save(show);
+
+		List<Seat> seats = TestFixture.getSeatList(show, show.getShowPeriod().getStartDate(), 1);
+		List<Seat> savedSeats = seatRepository.saveAll(seats);
+		List<Long> idList = savedSeats.stream()
+			.map(Seat::getId)
+			.toList();
+
+		// when
+		executorService.invokeAll(getCallables2(user, idList));
+
+		// then
+		List<Booking> bookingList = bookingRepository.findAll();
+		assertEquals(2, bookingList.size());
+	}
+
+	private List<Callable<TicketBookingResponse>> getCallables1(User user, List<Long> idList) {
+		List<Callable<TicketBookingResponse>> callables = new ArrayList<>();
+		for (int i = 0; i < 100; i++) {
+			callables.add(() -> ticketBookingFacade.bookingTicket(user.getId(), new TicketBookingRequest(idList)));
+		}
+		return callables;
+	}
+
+	private List<Callable<TicketBookingResponse>> getCallables2(User user, List<Long> idList) {
+		List<Callable<TicketBookingResponse>> callables = new ArrayList<>();
+		callables.add(
+			() -> ticketBookingFacade.bookingTicket(user.getId(),
+				new TicketBookingRequest(List.of(idList.get(0), idList.get(1), idList.get(2)))));
+		callables.add(
+			() -> ticketBookingFacade.bookingTicket(user.getId(),
+				new TicketBookingRequest(List.of(idList.get(2), idList.get(3)))));
+		callables.add(
+			() -> ticketBookingFacade.bookingTicket(user.getId(), new TicketBookingRequest(List.of(idList.get(4)))));
+		return callables;
+	}
+
+}

--- a/core/src/test/java/dev/hooon/booking/application/fascade/TicketBookingFacadeIntegrationTest.java
+++ b/core/src/test/java/dev/hooon/booking/application/fascade/TicketBookingFacadeIntegrationTest.java
@@ -72,7 +72,8 @@ class TicketBookingFacadeIntegrationTest extends TestContainerSupport {
 	void bookingTicket_success_test() {
 
 		// given
-		User user = new User("user@email.com", "user", BUYER);
+		// User user = new User("user@email.com", "user", BUYER);
+		User user = User.ofBuyer("user@email.com", "user", BUYER.toString());
 		userRepository.save(user);
 
 		Place place = TestFixture.getPlace();
@@ -103,7 +104,8 @@ class TicketBookingFacadeIntegrationTest extends TestContainerSupport {
 	void bookingTicket_fail_test_1() {
 
 		// given
-		User user = new User("user@email.com", "user", BUYER);
+		// User user = new User("user@email.com", "user", BUYER);
+		User user = User.ofBuyer("user@email.com", "user", BUYER.toString());
 		userRepository.save(user);
 
 		Place place = TestFixture.getPlace();
@@ -131,7 +133,8 @@ class TicketBookingFacadeIntegrationTest extends TestContainerSupport {
 	void bookingTicket_fail_test_2() {
 
 		// given
-		User user = new User("user@email.com", "user", BUYER);
+		// User user = new User("user@email.com", "user", BUYER);
+		User user = User.ofBuyer("user@email.com", "user", BUYER.toString());
 		userRepository.save(user);
 
 		Place place = TestFixture.getPlace();
@@ -161,7 +164,8 @@ class TicketBookingFacadeIntegrationTest extends TestContainerSupport {
 		// given
 		ExecutorService executorService = Executors.newFixedThreadPool(100);
 
-		User user = new User("user@email.com", "user", BUYER);
+		// User user = new User("user@email.com", "user", BUYER);
+		User user = User.ofBuyer("user@email.com", "user", BUYER.toString());
 		userRepository.save(user);
 
 		Place place = TestFixture.getPlace();
@@ -191,7 +195,8 @@ class TicketBookingFacadeIntegrationTest extends TestContainerSupport {
 		// given
 		ExecutorService executorService = Executors.newFixedThreadPool(3);
 
-		User user = new User("user@email.com", "user", BUYER);
+		// User user = new User("user@email.com", "user", BUYER);
+		User user = User.ofBuyer("user@email.com", "user", BUYER.toString());
 		userRepository.save(user);
 
 		Place place = TestFixture.getPlace();

--- a/core/src/test/java/dev/hooon/booking/application/fascade/TicketBookingFacadeTest.java
+++ b/core/src/test/java/dev/hooon/booking/application/fascade/TicketBookingFacadeTest.java
@@ -1,0 +1,105 @@
+package dev.hooon.booking.application.fascade;
+
+import static dev.hooon.booking.exception.BookingErrorCode.*;
+import static dev.hooon.user.domain.entity.UserRole.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import dev.hooon.booking.application.BookingService;
+import dev.hooon.booking.dto.request.TicketBookingRequest;
+import dev.hooon.common.exception.ValidationException;
+import dev.hooon.common.fixture.TestFixture;
+import dev.hooon.show.application.SeatService;
+import dev.hooon.show.domain.entity.Show;
+import dev.hooon.show.domain.entity.place.Place;
+import dev.hooon.show.domain.entity.seat.Seat;
+import dev.hooon.user.application.UserService;
+import dev.hooon.user.domain.entity.User;
+
+@DisplayName("[TicketBookingFacade 메서드 단위 테스트]")
+@ExtendWith(MockitoExtension.class)
+class TicketBookingFacadeTest {
+
+	@InjectMocks
+	private TicketBookingFacade ticketBookingFacade;
+
+	@Mock
+	private BookingService bookingService;
+
+	@Mock
+	private SeatService seatService;
+
+	@Mock
+	private UserService userService;
+
+	@DisplayName("seatList가 비어있으면 예외가 발생한다")
+	@Test
+	void validateSeatList_test_1() {
+
+		// given
+		User user = new User("user@email.com", "user", BUYER);
+		TicketBookingRequest ticketBookingRequest = new TicketBookingRequest(List.of());
+
+		when(userService.getUserById(1L)).thenReturn(user);
+
+		// when, then
+		assertThrows(
+			ValidationException.class,
+			() -> ticketBookingFacade.bookingTicket(1L, ticketBookingRequest),
+			INVALID_EMPTY_SEAT.getMessage()
+		);
+	}
+
+	@DisplayName("요청한 좌석수와 seatList의 사이즈가 다르면 예외가 발생한다")
+	@Test
+	void validateSeatList_test_2() {
+
+		// given
+		User user = new User("user@email.com", "user", BUYER);
+		TicketBookingRequest ticketBookingRequest = new TicketBookingRequest(List.of(1L, 2L, 3L));
+
+		when(userService.getUserById(1L)).thenReturn(user);
+		when(seatService.findByIdIn(ticketBookingRequest.seatIds())).thenReturn(List.of());
+
+		// when, then
+		assertThrows(
+			ValidationException.class,
+			() -> ticketBookingFacade.bookingTicket(1L, ticketBookingRequest),
+			INVALID_SELECTED_SEAT.getMessage()
+		);
+	}
+
+	@DisplayName("좌석들 중 seatStatus가 AVAILABLE 이지 않은 좌석이 하나라도 있으면 예외가 발생한다.")
+	@Test
+	void validateAvailableSeat_test() {
+
+		// given
+		User user = new User("user@email.com", "user", BUYER);
+		Place place = TestFixture.getPlace();
+		Show show = TestFixture.getShow(place);
+		List<Seat> seatList = TestFixture.getSeatList(show, show.getShowPeriod().getStartDate(), 1);
+		TicketBookingRequest ticketBookingRequest = new TicketBookingRequest(
+			seatList.stream().map(Seat::getId).toList());
+		seatList.get(0).markSeatStatusAsBooked();
+
+		when(userService.getUserById(1L)).thenReturn(user);
+		when(seatService.findByIdIn(seatList.stream().map(Seat::getId).toList())).thenReturn(seatList);
+
+		// when, then
+		assertThrows(
+			ValidationException.class,
+			() -> ticketBookingFacade.bookingTicket(1L, ticketBookingRequest),
+			NOT_AVAILABLE_SEAT.getMessage()
+		);
+	}
+
+}

--- a/core/src/test/java/dev/hooon/booking/application/fascade/TicketBookingFacadeTest.java
+++ b/core/src/test/java/dev/hooon/booking/application/fascade/TicketBookingFacadeTest.java
@@ -46,7 +46,8 @@ class TicketBookingFacadeTest {
 	void validateSeatList_test_1() {
 
 		// given
-		User user = new User("user@email.com", "user", BUYER);
+		// User user = new User("user@email.com", "user", BUYER);
+		User user = User.ofBuyer("user@email.com", "user", BUYER.toString());
 		TicketBookingRequest ticketBookingRequest = new TicketBookingRequest(List.of());
 
 		when(userService.getUserById(1L)).thenReturn(user);
@@ -64,7 +65,8 @@ class TicketBookingFacadeTest {
 	void validateSeatList_test_2() {
 
 		// given
-		User user = new User("user@email.com", "user", BUYER);
+		// User user = new User("user@email.com", "user", BUYER);
+		User user = User.ofBuyer("user@email.com", "user", BUYER.toString());
 		TicketBookingRequest ticketBookingRequest = new TicketBookingRequest(List.of(1L, 2L, 3L));
 
 		when(userService.getUserById(1L)).thenReturn(user);
@@ -83,7 +85,8 @@ class TicketBookingFacadeTest {
 	void validateAvailableSeat_test() {
 
 		// given
-		User user = new User("user@email.com", "user", BUYER);
+		// User user = new User("user@email.com", "user", BUYER);
+		User user = User.ofBuyer("user@email.com", "user", BUYER.toString());
 		Place place = TestFixture.getPlace();
 		Show show = TestFixture.getShow(place);
 		List<Seat> seatList = TestFixture.getSeatList(show, show.getShowPeriod().getStartDate(), 1);

--- a/core/src/test/java/dev/hooon/show/domain/entity/seat/SeatTest.java
+++ b/core/src/test/java/dev/hooon/show/domain/entity/seat/SeatTest.java
@@ -1,0 +1,52 @@
+package dev.hooon.show.domain.entity.seat;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import dev.hooon.common.fixture.SeatFixture;
+
+@DisplayName("[Seat 도메인 단위 테스트]")
+class SeatTest {
+
+	@DisplayName("해당 좌석의 isSeat값이 false이면 해당 좌석은 예매 가능하지 않다.")
+	@Test
+	void isBookingAvailableTest1() {
+		// given
+		Seat seat = SeatFixture.getSeatWithIsSeat(false);
+
+		// when, then
+		assertFalse(seat.isBookingAvailable());
+	}
+
+	@DisplayName("해당 좌석의 seatStatus 값이 AVAILABLE이 아니면 해당 좌석은 예매 가능하지 않다.")
+	@Test
+	void isBookingAvailableTest2() {
+		// given
+		Seat seat1 = SeatFixture.getSeat(SeatStatus.BOOKED);
+		Seat seat2 = SeatFixture.getSeat(SeatStatus.WAITING);
+		Seat seat3 = SeatFixture.getSeat(SeatStatus.CANCELED);
+
+		// when, then
+		assertAll(
+			() -> assertFalse(seat1.isBookingAvailable()),
+			() -> assertFalse(seat2.isBookingAvailable()),
+			() -> assertFalse(seat3.isBookingAvailable())
+		);
+	}
+
+	@DisplayName("해당 좌석이 예매가 되면, 해당 좌석의 SeatStatus는 'BOOKED'으로 변경된다")
+	@Test
+	void markSeatStatusAsBookedTest() {
+		// given
+		Seat seat = SeatFixture.getSeat();
+
+		// when
+		seat.markSeatStatusAsBooked();
+
+		// then
+		assertThat(seat.getSeatStatus()).isEqualTo(SeatStatus.BOOKED);
+	}
+}

--- a/core/src/test/java/dev/hooon/show/domain/repository/SeatRepositoryTest.java
+++ b/core/src/test/java/dev/hooon/show/domain/repository/SeatRepositoryTest.java
@@ -145,4 +145,26 @@ class SeatRepositoryTest extends DataJpaTestSupport {
 		//then
 		assertThat(result).isEqualTo(show.getName());
 	}
+
+	@Test
+	@DisplayName("[id 리스트에 포함된 좌석들을 조회할 수 있다]")
+	void findByIdInTest() {
+
+		// given
+		List<Seat> seats = List.of(
+			SeatFixture.getSeat(),
+			SeatFixture.getSeat(),
+			SeatFixture.getSeat()
+		);
+		seatRepository.saveAll(seats);
+
+		List<Long> idList = seats.stream().map(Seat::getId).toList();
+
+		// when
+		List<Seat> seatList = seatRepository.findByIdIn(idList);
+
+		// then
+		assertEquals(seatList, seats);
+	}
+
 }

--- a/core/src/testFixtures/java/dev/hooon/common/fixture/SeatFixture.java
+++ b/core/src/testFixtures/java/dev/hooon/common/fixture/SeatFixture.java
@@ -1,5 +1,7 @@
 package dev.hooon.common.fixture;
 
+import static dev.hooon.show.domain.entity.seat.SeatStatus.*;
+
 import java.time.LocalDate;
 import java.time.LocalTime;
 
@@ -39,7 +41,7 @@ public class SeatFixture {
 			showDate,
 			round,
 			startTime,
-			SeatStatus.AVAILABLE
+			AVAILABLE
 		);
 	}
 
@@ -64,6 +66,22 @@ public class SeatFixture {
 		);
 	}
 
+	public static Seat getSeatWithIsSeat(boolean isSeat) {
+		return Seat.of(
+			SHOW,
+			SeatGrade.VIP,
+			isSeat,
+			"1층",
+			"A",
+			10,
+			100000,
+			LocalDate.now(),
+			1,
+			LocalTime.now(),
+			AVAILABLE
+		);
+	}
+
 	public static Seat getSeat(Long seatId) {
 		Seat seat = getSeat(LocalDate.now(), 1, LocalTime.now());
 		ReflectionTestUtils.setField(seat, "id", seatId);
@@ -82,7 +100,7 @@ public class SeatFixture {
 			LocalDate.now(),
 			1,
 			LocalTime.now(),
-			SeatStatus.AVAILABLE
+			AVAILABLE
 		);
 	}
 }

--- a/core/src/testFixtures/java/dev/hooon/common/fixture/TestFixture.java
+++ b/core/src/testFixtures/java/dev/hooon/common/fixture/TestFixture.java
@@ -54,6 +54,34 @@ public class TestFixture {
 		return List.of(vipSeat1, vipSeat2, sSeat1, sSeat2, aSeat);
 	}
 
+	public static List<Seat> getReservedSeats(Show show, LocalDate date, int round) {
+		Seat vipSeat1 = Seat.of(show, VIP, true, "1층", "A", 2, 100000, date, round, LocalTime.of(14, 0),
+			BOOKED);
+		Seat vipSeat2 = Seat.of(show, VIP, true, "1층", "A", 3, 100000, date, round, LocalTime.of(14, 0),
+			BOOKED);
+		Seat sSeat1 = Seat.of(show, S, true, "2층", "A", 2, 70000, date, round, LocalTime.of(14, 0),
+			BOOKED);
+		Seat sSeat2 = Seat.of(show, S, true, "2층", "A", 3, 70000, date, round, LocalTime.of(14, 0),
+			AVAILABLE);
+		Seat aSeat = Seat.of(show, A, true, "3층", "A", 2, 50000, date, round, LocalTime.of(14, 0),
+			AVAILABLE);
+		return List.of(vipSeat1, vipSeat2, sSeat1, sSeat2, aSeat);
+	}
+
+	public static List<Seat> getNonValidSeats(Show show, LocalDate date, int round) {
+		Seat vipSeat1 = Seat.of(show, VIP, false, "1층", "A", 2, 100000, date, round, LocalTime.of(14, 0),
+			AVAILABLE);
+		Seat vipSeat2 = Seat.of(show, VIP, false, "1층", "A", 3, 100000, date, round, LocalTime.of(14, 0),
+			AVAILABLE);
+		Seat sSeat1 = Seat.of(show, S, true, "2층", "A", 2, 70000, date, round, LocalTime.of(14, 0),
+			AVAILABLE);
+		Seat sSeat2 = Seat.of(show, S, true, "2층", "A", 3, 70000, date, round, LocalTime.of(14, 0),
+			AVAILABLE);
+		Seat aSeat = Seat.of(show, A, true, "3층", "A", 2, 50000, date, round, LocalTime.of(14, 0),
+			AVAILABLE);
+		return List.of(vipSeat1, vipSeat2, sSeat1, sSeat2, aSeat);
+	}
+
 	public static List<Seat> getVipSeatList(Show show, LocalDate date, int round) {
 		Seat vipSeat1 = Seat.of(show, VIP, true, "1층", "A", 2, 100000, date, round, LocalTime.of(14, 0),
 			AVAILABLE);

--- a/core/src/testFixtures/resources/sql/booking_dummy.sql
+++ b/core/src/testFixtures/resources/sql/booking_dummy.sql
@@ -1,0 +1,24 @@
+INSERT INTO place_table
+    (place_name, place_contact_info, place_address, place_url)
+VALUES ('블루스퀘어 신한카드홀', '1544-1591', '서울특별시 용산구 이태원로 294 블루스퀘어(한남동)', 'http://www.bluesquare.kr/index.asp');
+
+
+INSERT INTO show_table
+(show_id, show_name, show_category, show_start_date, show_end_date, show_total_minutes, show_intermission_minutes,
+ show_age_limit, show_total_seats, show_place_id)
+VALUES (1, '레미제라블', 'MUSICAL', '2024-01-01', '2024-12-31', 150, 15, '만 8세 이상', 1000, 1);
+
+INSERT INTO seat_table
+(seat_show_id, seat_grade, seat_is_seat, seat_sector, seat_row, seat_col, seat_price, seat_show_date,
+ seat_show_round, seat_start_time, seat_status)
+VALUES (1, 'VIP', true, '1층', 'A', 2, 100000, '2024-01-01', 2, '13:00:00', 'AVAILABLE');
+
+INSERT INTO seat_table
+(seat_show_id, seat_grade, seat_is_seat, seat_sector, seat_row, seat_col, seat_price, seat_show_date,
+ seat_show_round, seat_start_time, seat_status)
+VALUES (1, 'VIP', true, '1층', 'A', 3, 100000, '2024-01-01', 2, '13:00:00', 'AVAILABLE');
+
+INSERT INTO seat_table
+(seat_show_id, seat_grade, seat_is_seat, seat_sector, seat_row, seat_col, seat_price, seat_show_date,
+ seat_show_round, seat_start_time, seat_status)
+VALUES (1, 'S', true, '2층', 'A', 2, 70000, '2024-01-01', 2, '13:00:00', 'AVAILABLE');


### PR DESCRIPTION
- closed #46 

## 📄 무엇을 개발했나요? 
* 공연 예매 controller, application, repository 구현 및 각 레이어 별 테스트 구현 완료
* 동시에 동일 좌석에 대한 예매에 대해 pessimistic lock을 이용해 동시성을 처리하였습니다 -> 시간되면 레디스를 이용한 방법도 추가해보고 이 둘의 성능을 비교해보려고 합니다
* 예매 로직이 추가되면서 각 도메인 내에서 validation을 처리해야하는 로직들이 많아져서, 각 도메인 정책에 해당하는 메서드를 추가하고, 단위테스트까지 모두 작성하였습니다
* 예매 로직에 대해 각 메서드 별 단위테스트, 그리고 전체 통합테스트, 동시성 테스트까지 모두 작성하였습니다

## 🍸 무엇을 집중적으로 리뷰해야할까요?
* 네이밍, 컨벤션 확인
* 예매 비즈니즈 로직 확인 및 점검
* 동시성 처리 부분 확인 및 점검