### PR TITLE
[feat]: 공연 예매 취소 API 추가

### DIFF
--- a/api/src/main/java/dev/hooon/bookingcancel/BookingCancelApiController.java
+++ b/api/src/main/java/dev/hooon/bookingcancel/BookingCancelApiController.java
@@ -1,0 +1,30 @@
+package dev.hooon.bookingcancel;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import dev.hooon.booking.application.BookingService;
+import dev.hooon.booking.dto.response.BookingCancelResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class BookingCancelApiController {
+
+	private final BookingService bookingService;
+
+	@PostMapping("/api/bookings/cancel/{booking_id}")
+	public ResponseEntity<BookingCancelResponse> cancelBooking(
+		@RequestParam(name = "userId") Long userId, // TODO
+		@PathVariable("booking_id") Long bookingId
+	) {
+		BookingCancelResponse bookingCancelResponse = bookingService.cancelBooking(
+			userId,
+			bookingId
+		);
+		return ResponseEntity.ok(bookingCancelResponse);
+	}
+}

--- a/api/src/test/java/dev/hooon/bookingcancel/BookingCancelApiControllerTest.java
+++ b/api/src/test/java/dev/hooon/bookingcancel/BookingCancelApiControllerTest.java
@@ -1,0 +1,88 @@
+package dev.hooon.bookingcancel;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import dev.hooon.booking.dto.request.TicketBookingRequest;
+import dev.hooon.common.support.ApiTestSupport;
+import dev.hooon.user.application.UserService;
+import dev.hooon.user.domain.entity.User;
+
+@DisplayName("[BookingCancelApiController API 테스트]")
+@Sql("/sql/booking_cancel_dummy.sql")
+class BookingCancelApiControllerTest extends ApiTestSupport {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private UserService userService;
+
+	@DisplayName("사용자는 예매한 티켓을 취소할 수 있다.")
+	@Test
+	void cancelBookingTest() throws Exception {
+
+		// given
+		User user = new User();
+		ReflectionTestUtils.setField(user, "id", 1L);
+		given(userService.getUserById(1L)).willReturn(user);
+
+		// 예약 API 먼저
+		long bookingId = doBooking();
+
+		// when
+		ResultActions resultActions = mockMvc.perform(
+			MockMvcRequestBuilders
+				.post("/api/bookings/cancel/" + bookingId)
+				.queryParam("userId", "1") // TODO: 인증 구현되면 수정할 것
+		);
+
+		// then
+		resultActions.andExpectAll(
+			status().isOk(),
+
+			jsonPath("$.bookingStatus").isString(),
+			jsonPath("$.canceledTickets").isArray(),
+
+			jsonPath("$.canceledTickets[0].seatId").isNumber(),
+			jsonPath("$.canceledTickets[0].seatStatus").isString(),
+
+			jsonPath("$.canceledTickets[1].seatId").isNumber(),
+			jsonPath("$.canceledTickets[1].seatStatus").isString(),
+
+			jsonPath("$.canceledTickets[2].seatId").isNumber(),
+			jsonPath("$.canceledTickets[2].seatStatus").isString()
+		);
+	}
+
+	private long doBooking() throws Exception {
+		TicketBookingRequest ticketBookingRequest = new TicketBookingRequest(List.of(1L, 2L, 3L));
+		ResultActions resultActions = mockMvc.perform(
+			MockMvcRequestBuilders
+				.post("/api/bookings")
+				.queryParam("userId", "1") // TODO: 인증 구현되면 수정할 것
+				.accept(APPLICATION_JSON)
+				.contentType(APPLICATION_JSON)
+				.content(toJson(ticketBookingRequest))
+		);
+		String contentAsString = resultActions.andReturn().getResponse().getContentAsString();
+		JSONObject jsonObject = new JSONObject(contentAsString);
+		String bookingId = jsonObject.getString("bookingId");
+		return Long.parseLong(bookingId);
+	}
+
+}

--- a/api/src/test/java/dev/hooon/ticketbooking/TicketBookingApiControllerTest.java
+++ b/api/src/test/java/dev/hooon/ticketbooking/TicketBookingApiControllerTest.java
@@ -55,6 +55,7 @@ class TicketBookingApiControllerTest extends ApiTestSupport {
 		resultActions.andExpectAll(
 			status().isOk(),
 
+			jsonPath("$.bookingId").isNumber(),
 			jsonPath("$.bookingTickets").isArray(),
 
 			jsonPath("$.bookingTickets[0].ticketId").isNumber(),

--- a/core/src/main/java/dev/hooon/booking/application/BookingService.java
+++ b/core/src/main/java/dev/hooon/booking/application/BookingService.java
@@ -1,9 +1,18 @@
 package dev.hooon.booking.application;
 
+import static dev.hooon.booking.exception.BookingErrorCode.*;
+
 import org.springframework.stereotype.Service;
 
 import dev.hooon.booking.domain.entity.Booking;
+import dev.hooon.booking.domain.entity.BookingStatus;
+import dev.hooon.booking.domain.entity.Ticket;
 import dev.hooon.booking.domain.repository.BookingRepository;
+import dev.hooon.booking.dto.BookingMapper;
+import dev.hooon.booking.dto.response.BookingCancelResponse;
+import dev.hooon.common.exception.NotFoundException;
+import dev.hooon.common.exception.ValidationException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -12,7 +21,48 @@ public class BookingService {
 
 	private final BookingRepository bookingRepository;
 
+	private void validateIdenticalUser(Long userId, Booking booking) {
+		if (booking.getUserId() != userId) {
+			throw new ValidationException(NOT_IDENTICAL_USER);
+		}
+	}
+
+	private void validateBookingStatus(Booking booking) {
+		if (booking.getBookingStatus() != BookingStatus.BOOKED) {
+			throw new ValidationException(ALREADY_CANCELED_BOOKING);
+		}
+	}
+
+	@Transactional
+	public BookingCancelResponse cancelBooking(
+		Long userId,
+		Long bookingId
+	) {
+		// 1. bookingId로 booking 가져오기
+		// 1.1 해당 userId와 동일한지 확인
+		// 1.2 bookingStatus 확인
+		Booking booking = findById(bookingId);
+		validateIdenticalUser(userId, booking);
+		validateBookingStatus(booking);
+
+		// 2. booking의 모든 티켓들의 좌석 상태 'SeatStatus' 변경시키기 : BOOKED -> CANCELED
+		booking.getTickets()
+			.forEach(Ticket::markSeatStatusAsCanceled);
+
+		// 3. booking의 'BookingStatus' 변경시키기 : BOOKED -> CANCELED
+		booking.markBookingStatusAsCanceled();
+
+		return BookingMapper.toBookingCancelResponse(booking);
+	}
+
 	public Booking bookingTicket(Booking booking) {
 		return bookingRepository.save(booking);
 	}
+
+	public Booking findById(Long id) {
+		return bookingRepository.findById(id).orElseThrow(
+			() -> new NotFoundException(BOOKING_NOT_FOUND)
+		);
+	}
+
 }

--- a/core/src/main/java/dev/hooon/booking/application/BookingService.java
+++ b/core/src/main/java/dev/hooon/booking/application/BookingService.java
@@ -60,7 +60,7 @@ public class BookingService {
 	}
 
 	public Booking findById(Long id) {
-		return bookingRepository.findById(id).orElseThrow(
+		return bookingRepository.findByIdWithTickets(id).orElseThrow(
 			() -> new NotFoundException(BOOKING_NOT_FOUND)
 		);
 	}

--- a/core/src/main/java/dev/hooon/booking/application/BookingService.java
+++ b/core/src/main/java/dev/hooon/booking/application/BookingService.java
@@ -41,7 +41,7 @@ public class BookingService {
 		// 1. bookingId로 booking 가져오기
 		// 1.1 해당 userId와 동일한지 확인
 		// 1.2 bookingStatus 확인
-		Booking booking = findById(bookingId);
+		Booking booking = getById(bookingId);
 		validateIdenticalUser(userId, booking);
 		validateBookingStatus(booking);
 
@@ -59,7 +59,7 @@ public class BookingService {
 		return bookingRepository.save(booking);
 	}
 
-	public Booking findById(Long id) {
+	public Booking getById(Long id) {
 		return bookingRepository.findByIdWithTickets(id).orElseThrow(
 			() -> new NotFoundException(BOOKING_NOT_FOUND)
 		);

--- a/core/src/main/java/dev/hooon/booking/domain/entity/Booking.java
+++ b/core/src/main/java/dev/hooon/booking/domain/entity/Booking.java
@@ -70,4 +70,12 @@ public class Booking extends TimeBaseEntity {
 	) {
 		return new Booking(user, show);
 	}
+
+	public void markBookingStatusAsCanceled() {
+		this.bookingStatus = CANCELED;
+	}
+
+	public long getUserId() {
+		return this.user.getId();
+	}
 }

--- a/core/src/main/java/dev/hooon/booking/domain/entity/Ticket.java
+++ b/core/src/main/java/dev/hooon/booking/domain/entity/Ticket.java
@@ -50,4 +50,8 @@ public class Ticket extends TimeBaseEntity {
 	public void setBooking(Booking booking) {
 		this.booking = booking;
 	}
+
+	public void markSeatStatusAsCanceled() {
+		this.seat.markSeatStatusAsCanceled();
+	}
 }

--- a/core/src/main/java/dev/hooon/booking/domain/repository/BookingRepository.java
+++ b/core/src/main/java/dev/hooon/booking/domain/repository/BookingRepository.java
@@ -1,6 +1,7 @@
 package dev.hooon.booking.domain.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import dev.hooon.booking.domain.entity.Booking;
 
@@ -9,4 +10,6 @@ public interface BookingRepository {
 	Booking save(Booking booking);
 
 	List<Booking> findAll();
+
+	Optional<Booking> findById(Long id);
 }

--- a/core/src/main/java/dev/hooon/booking/domain/repository/BookingRepository.java
+++ b/core/src/main/java/dev/hooon/booking/domain/repository/BookingRepository.java
@@ -11,5 +11,5 @@ public interface BookingRepository {
 
 	List<Booking> findAll();
 
-	Optional<Booking> findById(Long id);
+	Optional<Booking> findByIdWithTickets(Long id);
 }

--- a/core/src/main/java/dev/hooon/booking/dto/BookingMapper.java
+++ b/core/src/main/java/dev/hooon/booking/dto/BookingMapper.java
@@ -3,8 +3,10 @@ package dev.hooon.booking.dto;
 import java.util.List;
 
 import dev.hooon.booking.domain.entity.Booking;
+import dev.hooon.booking.dto.response.BookingCancelResponse;
 import dev.hooon.booking.dto.response.TicketBookingResponse;
 import dev.hooon.booking.dto.response.TicketResponse;
+import dev.hooon.booking.dto.response.TicketSeatResponse;
 import dev.hooon.show.domain.entity.Show;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -26,6 +28,21 @@ public final class BookingMapper {
 				ticket.getSeat().getRound()
 			))
 			.toList();
-		return new TicketBookingResponse(ticketResponseList);
+		return new TicketBookingResponse(booking.getId(), ticketResponseList);
+	}
+
+	public static BookingCancelResponse toBookingCancelResponse(Booking booking) {
+		List<TicketSeatResponse> ticketSeatResponseList = booking.getTickets().stream()
+			.map(
+				ticket -> new TicketSeatResponse(
+					ticket.getSeat().getId(),
+					ticket.getSeat().getSeatStatus().toString()
+				)
+			)
+			.toList();
+		return new BookingCancelResponse(
+			booking.getBookingStatus().toString(),
+			ticketSeatResponseList
+		);
 	}
 }

--- a/core/src/main/java/dev/hooon/booking/dto/response/BookingCancelResponse.java
+++ b/core/src/main/java/dev/hooon/booking/dto/response/BookingCancelResponse.java
@@ -1,0 +1,9 @@
+package dev.hooon.booking.dto.response;
+
+import java.util.List;
+
+public record BookingCancelResponse(
+	String bookingStatus,
+	List<TicketSeatResponse> canceledTickets
+) {
+}

--- a/core/src/main/java/dev/hooon/booking/dto/response/TicketBookingResponse.java
+++ b/core/src/main/java/dev/hooon/booking/dto/response/TicketBookingResponse.java
@@ -3,6 +3,7 @@ package dev.hooon.booking.dto.response;
 import java.util.List;
 
 public record TicketBookingResponse(
+	long bookingId,
 	List<TicketResponse> bookingTickets
 ) {
 }

--- a/core/src/main/java/dev/hooon/booking/dto/response/TicketSeatResponse.java
+++ b/core/src/main/java/dev/hooon/booking/dto/response/TicketSeatResponse.java
@@ -1,0 +1,7 @@
+package dev.hooon.booking.dto.response;
+
+public record TicketSeatResponse(
+	long seatId,
+	String seatStatus
+) {
+}

--- a/core/src/main/java/dev/hooon/booking/exception/BookingErrorCode.java
+++ b/core/src/main/java/dev/hooon/booking/exception/BookingErrorCode.java
@@ -10,7 +10,10 @@ public enum BookingErrorCode implements ErrorCode {
 
 	INVALID_EMPTY_SEAT("좌석이 선택되지 않았습니다", "B_001"),
 	INVALID_SELECTED_SEAT("선택한 좌석값들 중 유효하지 않은 좌석값이 있습니다", "B_002"),
-	NOT_AVAILABLE_SEAT("좌석 중 예매가 불가능한 좌석이 있습니다", "B_003");
+	NOT_AVAILABLE_SEAT("좌석 중 예매가 불가능한 좌석이 있습니다", "B_003"),
+	BOOKING_NOT_FOUND("예매를 찾을 수 없습니다", "B_004"),
+	NOT_IDENTICAL_USER("예매한 유저가 동일하지 않습니다", "B_005"),
+	ALREADY_CANCELED_BOOKING("이미 취소된 예약입니다", "B_006");
 
 	private final String message;
 	private final String code;

--- a/core/src/main/java/dev/hooon/booking/infrastructure/adaptor/BookingRepositoryAdaptor.java
+++ b/core/src/main/java/dev/hooon/booking/infrastructure/adaptor/BookingRepositoryAdaptor.java
@@ -27,7 +27,7 @@ public class BookingRepositoryAdaptor implements BookingRepository {
 	}
 
 	@Override
-	public Optional<Booking> findById(Long id) {
-		return bookingJpaRepository.findById(id);
+	public Optional<Booking> findByIdWithTickets(Long id) {
+		return bookingJpaRepository.findByIdWithTickets(id);
 	}
 }

--- a/core/src/main/java/dev/hooon/booking/infrastructure/adaptor/BookingRepositoryAdaptor.java
+++ b/core/src/main/java/dev/hooon/booking/infrastructure/adaptor/BookingRepositoryAdaptor.java
@@ -1,6 +1,7 @@
 package dev.hooon.booking.infrastructure.adaptor;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
@@ -23,5 +24,10 @@ public class BookingRepositoryAdaptor implements BookingRepository {
 	@Override
 	public List<Booking> findAll() {
 		return bookingJpaRepository.findAll();
+	}
+
+	@Override
+	public Optional<Booking> findById(Long id) {
+		return bookingJpaRepository.findById(id);
 	}
 }

--- a/core/src/main/java/dev/hooon/booking/infrastructure/repository/BookingJpaRepository.java
+++ b/core/src/main/java/dev/hooon/booking/infrastructure/repository/BookingJpaRepository.java
@@ -1,8 +1,15 @@
 package dev.hooon.booking.infrastructure.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import dev.hooon.booking.domain.entity.Booking;
 
 public interface BookingJpaRepository extends JpaRepository<Booking, Long> {
+
+	@Query("SELECT DISTINCT b FROM Booking b LEFT JOIN FETCH b.tickets WHERE b.id = :bookingId")
+	Optional<Booking> findByIdWithTickets(@Param("bookingId") Long bookingId);
 }

--- a/core/src/main/java/dev/hooon/show/domain/entity/seat/Seat.java
+++ b/core/src/main/java/dev/hooon/show/domain/entity/seat/Seat.java
@@ -99,6 +99,31 @@ public class Seat extends TimeBaseEntity {
 		this.seatStatus = seatStatus;
 	}
 
+	private Seat(
+		Long id,
+		Show show,
+		SeatGrade seatGrade,
+		boolean isSeat,
+		String sector,
+		String row,
+		int col,
+		int price,
+		LocalDate showDate,
+		int round,
+		LocalTime startTime,
+		SeatStatus seatStatus
+	) {
+		this.id = id;
+		this.show = show;
+		this.seatGrade = seatGrade;
+		this.isSeat = isSeat;
+		this.positionInfo = new SeatPositionInfo(sector, row, col);
+		this.price = price;
+		this.showDate = showDate;
+		this.showRound = new ShowRound(round, startTime);
+		this.seatStatus = seatStatus;
+	}
+
 	public static Seat of(
 		Show show,
 		SeatGrade seatGrade,
@@ -115,6 +140,23 @@ public class Seat extends TimeBaseEntity {
 		return new Seat(show, seatGrade, isSeat, sector, row, col, price, showDate, round, startTime, seatStatus);
 	}
 
+	public static Seat of(
+		Long id,
+		Show show,
+		SeatGrade seatGrade,
+		boolean isSeat,
+		String sector,
+		String row,
+		int col,
+		int price,
+		LocalDate showDate,
+		int round,
+		LocalTime startTime,
+		SeatStatus seatStatus
+	) {
+		return new Seat(id, show, seatGrade, isSeat, sector, row, col, price, showDate, round, startTime, seatStatus);
+	}
+
 	public int getRound() {
 		return showRound.getRound();
 	}
@@ -129,6 +171,10 @@ public class Seat extends TimeBaseEntity {
 
 	public void markSeatStatusAsBooked() {
 		this.seatStatus = BOOKED;
+	}
+
+	public void markSeatStatusAsCanceled() {
+		this.seatStatus = CANCELED;
 	}
 
 	@Override

--- a/core/src/main/java/dev/hooon/user/domain/entity/User.java
+++ b/core/src/main/java/dev/hooon/user/domain/entity/User.java
@@ -54,6 +54,20 @@ public class User extends TimeBaseEntity {
 		this.userRole = userRole;
 	}
 
+	private User(
+		Long id,
+		String email,
+		String name,
+		String password,
+		UserRole userRole
+	) {
+		this.id = id;
+		this.email = email;
+		this.name = name;
+		this.password = password;
+		this.userRole = userRole;
+	}
+
 	private void validateUser(String email, String name, String password, UserRole userRole) {
 		Assert.hasText(email, getNotEmptyPostfix("User", "email"));
 		Assert.hasText(name, getNotEmptyPostfix("User", "name"));
@@ -69,5 +83,21 @@ public class User extends TimeBaseEntity {
 	) {
 		return new User(email, name, password, BUYER);
 	}
-  
+
+	/**
+	 * 테스트 용 유저 생성자
+	 *
+	 * @param id
+	 * @return
+	 */
+	public static User testUser(
+		Long id,
+		String email,
+		String name,
+		String password,
+		UserRole userRole
+	) {
+		return new User(id, email, name, password, userRole);
+	}
+
 }

--- a/core/src/test/java/dev/hooon/booking/application/BookingServiceTest.java
+++ b/core/src/test/java/dev/hooon/booking/application/BookingServiceTest.java
@@ -44,7 +44,7 @@ class BookingServiceTest {
 		// given
 		long userId = 1L;
 		long bookingId = 1L;
-		given(bookingRepository.findById(1L)).willReturn(Optional.empty());
+		given(bookingRepository.findByIdWithTickets(1L)).willReturn(Optional.empty());
 
 		// when, then
 		assertThrows(
@@ -64,7 +64,7 @@ class BookingServiceTest {
 		User user = TestFixture.getUser(userId);
 		Booking booking = Booking.of(user, TestFixture.getShow(TestFixture.getPlace()));
 
-		given(bookingRepository.findById(bookingId)).willReturn(Optional.of(booking));
+		given(bookingRepository.findByIdWithTickets(bookingId)).willReturn(Optional.of(booking));
 
 		// when, then
 		assertThrows(
@@ -84,7 +84,7 @@ class BookingServiceTest {
 		Booking booking = Booking.of(user, TestFixture.getShow(TestFixture.getPlace()));
 		booking.markBookingStatusAsCanceled();
 
-		given(bookingRepository.findById(bookingId)).willReturn(Optional.of(booking));
+		given(bookingRepository.findByIdWithTickets(bookingId)).willReturn(Optional.of(booking));
 
 		// when, then
 		assertThrows(
@@ -112,7 +112,7 @@ class BookingServiceTest {
 		allBookedSeats.forEach(
 			seat -> booking.addTicket(Ticket.of(seat))
 		);
-		given(bookingRepository.findById(bookingId)).willReturn(Optional.of(booking));
+		given(bookingRepository.findByIdWithTickets(bookingId)).willReturn(Optional.of(booking));
 
 		// when
 		BookingCancelResponse bookingCancelResponse = bookingService.cancelBooking(userId, bookingId);

--- a/core/src/test/java/dev/hooon/booking/application/BookingServiceTest.java
+++ b/core/src/test/java/dev/hooon/booking/application/BookingServiceTest.java
@@ -1,0 +1,125 @@
+package dev.hooon.booking.application;
+
+import static dev.hooon.booking.exception.BookingErrorCode.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import dev.hooon.booking.domain.entity.Booking;
+import dev.hooon.booking.domain.entity.BookingStatus;
+import dev.hooon.booking.domain.entity.Ticket;
+import dev.hooon.booking.domain.repository.BookingRepository;
+import dev.hooon.booking.dto.response.BookingCancelResponse;
+import dev.hooon.common.exception.NotFoundException;
+import dev.hooon.common.exception.ValidationException;
+import dev.hooon.common.fixture.TestFixture;
+import dev.hooon.show.domain.entity.Show;
+import dev.hooon.show.domain.entity.place.Place;
+import dev.hooon.show.domain.entity.seat.Seat;
+import dev.hooon.show.domain.entity.seat.SeatStatus;
+import dev.hooon.user.domain.entity.User;
+
+@DisplayName("[BookingService 테스트]")
+@ExtendWith(MockitoExtension.class)
+class BookingServiceTest {
+
+	@InjectMocks
+	private BookingService bookingService;
+
+	@Mock
+	private BookingRepository bookingRepository;
+
+	@DisplayName("취소하려는 예약이 존재하지 않으면 예외가 발생한다.")
+	@Test
+	void cancelBooking_fail_test_1() {
+		// given
+		long userId = 1L;
+		long bookingId = 1L;
+		given(bookingRepository.findById(1L)).willReturn(Optional.empty());
+
+		// when, then
+		assertThrows(
+			NotFoundException.class,
+			() -> bookingService.cancelBooking(userId, bookingId),
+			BOOKING_NOT_FOUND.getMessage()
+		);
+	}
+
+	@DisplayName("예약 취소하려는 유저와 예약을 한 유저가 다르면 예외가 발생한다.")
+	@Test
+	void cancelBooking_fail_test_2() {
+		// given
+		long bookingId = 1L;
+		long anotherUserId = 2L;
+		long userId = 1L;
+		User user = TestFixture.getUser(userId);
+		Booking booking = Booking.of(user, TestFixture.getShow(TestFixture.getPlace()));
+
+		given(bookingRepository.findById(bookingId)).willReturn(Optional.of(booking));
+
+		// when, then
+		assertThrows(
+			ValidationException.class,
+			() -> bookingService.cancelBooking(anotherUserId, bookingId),
+			NOT_IDENTICAL_USER.getMessage()
+		);
+	}
+
+	@DisplayName("이미 예약이 취소된 예약을 다시 취소하려고 하면 예외가 발생한다.")
+	@Test
+	void cancelBooking_fail_test_3() {
+		// given
+		long bookingId = 1L;
+		long userId = 1L;
+		User user = TestFixture.getUser(userId);
+		Booking booking = Booking.of(user, TestFixture.getShow(TestFixture.getPlace()));
+		booking.markBookingStatusAsCanceled();
+
+		given(bookingRepository.findById(bookingId)).willReturn(Optional.of(booking));
+
+		// when, then
+		assertThrows(
+			ValidationException.class,
+			() -> bookingService.cancelBooking(userId, bookingId),
+			ALREADY_CANCELED_BOOKING.getMessage()
+		);
+	}
+
+	@DisplayName("예약 취소 시, 예약 상태 그리고 예약의 모든 좌석 상태가 '취소' 상태로 변경된다.")
+	@Test
+	void cancelBooking_success_test() {
+		// given
+		long bookingId = 1L;
+		long userId = 1L;
+		User user = TestFixture.getUser(userId);
+		Place place = TestFixture.getPlace();
+		Show show = TestFixture.getShow(place);
+		List<Seat> allBookedSeats = TestFixture.getAllBookedSeats(
+			show,
+			show.getShowPeriod().getStartDate(),
+			1
+		);
+		Booking booking = Booking.of(user, show);
+		allBookedSeats.forEach(
+			seat -> booking.addTicket(Ticket.of(seat))
+		);
+		given(bookingRepository.findById(bookingId)).willReturn(Optional.of(booking));
+
+		// when
+		BookingCancelResponse bookingCancelResponse = bookingService.cancelBooking(userId, bookingId);
+
+		// then
+		assertEquals(BookingStatus.CANCELED.toString(), bookingCancelResponse.bookingStatus());
+		bookingCancelResponse.canceledTickets()
+			.forEach(ticket -> assertEquals(SeatStatus.CANCELED.toString(), ticket.seatStatus()));
+	}
+}

--- a/core/src/test/java/dev/hooon/booking/infrastructure/repository/BookingJpaRepositoryTest.java
+++ b/core/src/test/java/dev/hooon/booking/infrastructure/repository/BookingJpaRepositoryTest.java
@@ -1,0 +1,81 @@
+package dev.hooon.booking.infrastructure.repository;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import dev.hooon.booking.domain.entity.Booking;
+import dev.hooon.booking.domain.entity.Ticket;
+import dev.hooon.common.fixture.SeatFixture;
+import dev.hooon.common.fixture.TestFixture;
+import dev.hooon.common.support.TestContainerSupport;
+import dev.hooon.show.domain.entity.Show;
+import dev.hooon.show.domain.entity.place.Place;
+import dev.hooon.show.domain.entity.seat.Seat;
+import dev.hooon.show.infrastructure.repository.PlaceJpaRepository;
+import dev.hooon.show.infrastructure.repository.SeatJpaRepository;
+import dev.hooon.show.infrastructure.repository.ShowJpaRepository;
+import dev.hooon.user.domain.entity.User;
+import dev.hooon.user.infrastructure.repository.UserJpaRepository;
+import jakarta.transaction.Transactional;
+
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = NONE)
+class BookingJpaRepositoryTest extends TestContainerSupport {
+
+	@Autowired
+	private BookingJpaRepository bookingRepository;
+
+	@Autowired
+	private UserJpaRepository userRepository;
+
+	@Autowired
+	private ShowJpaRepository showRepository;
+
+	@Autowired
+	private SeatJpaRepository seatRepository;
+
+	@Autowired
+	private PlaceJpaRepository placeRepository;
+
+	@DisplayName("예약 조회 시 예약 티켓까지 한 번에 fetch join으로 데이터를 가져온다.")
+	@Test
+	@Transactional
+	void findByIdWithTickets_test() {
+		// given
+		User user = TestFixture.getUser(1L);
+		userRepository.save(user);
+		Place place = TestFixture.getPlace();
+		placeRepository.save(place);
+		Show show = TestFixture.getShow(place);
+		showRepository.save(show);
+		Seat seat1 = SeatFixture.getSeat();
+		Seat seat2 = SeatFixture.getSeat();
+		seatRepository.saveAll(List.of(seat1, seat2));
+		Booking booking = Booking.of(user, show);
+		booking.addTicket(Ticket.of(seat1));
+		booking.addTicket(Ticket.of(seat2));
+		Booking savedBooking = bookingRepository.save(booking);
+
+		// when
+		Optional<Booking> bookingWithTickets = bookingRepository.findByIdWithTickets(savedBooking.getId());
+
+		// then
+		assertAll(
+			() -> assertThat(bookingWithTickets).isPresent(),
+			() -> assertThat(bookingWithTickets.get().getTickets()).hasSize(2)
+		);
+		List<Ticket> tickets = bookingWithTickets.get().getTickets();
+		List<Seat> seats = tickets.stream().map(Ticket::getSeat).toList();
+		assertThat(seats).containsExactlyInAnyOrderElementsOf(List.of(seat1, seat2));
+	}
+}

--- a/core/src/testFixtures/java/dev/hooon/common/fixture/TestFixture.java
+++ b/core/src/testFixtures/java/dev/hooon/common/fixture/TestFixture.java
@@ -3,6 +3,7 @@ package dev.hooon.common.fixture;
 import static dev.hooon.show.domain.entity.ShowCategory.*;
 import static dev.hooon.show.domain.entity.seat.SeatGrade.*;
 import static dev.hooon.show.domain.entity.seat.SeatStatus.*;
+import static dev.hooon.user.domain.entity.UserRole.*;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -14,6 +15,7 @@ import dev.hooon.show.domain.entity.ShowTime;
 import dev.hooon.show.domain.entity.place.Place;
 import dev.hooon.show.domain.entity.seat.Seat;
 import dev.hooon.show.dto.query.seats.SeatsDetailDto;
+import dev.hooon.user.domain.entity.User;
 
 public class TestFixture {
 
@@ -68,6 +70,20 @@ public class TestFixture {
 		return List.of(vipSeat1, vipSeat2, sSeat1, sSeat2, aSeat);
 	}
 
+	public static List<Seat> getAllBookedSeats(Show show, LocalDate date, int round) {
+		Seat vipSeat1 = Seat.of(1L, show, VIP, true, "1층", "A", 2, 100000, date, round, LocalTime.of(14, 0),
+			BOOKED);
+		Seat vipSeat2 = Seat.of(2L, show, VIP, true, "1층", "A", 3, 100000, date, round, LocalTime.of(14, 0),
+			BOOKED);
+		Seat sSeat1 = Seat.of(3L, show, S, true, "2층", "A", 2, 70000, date, round, LocalTime.of(14, 0),
+			BOOKED);
+		Seat sSeat2 = Seat.of(4L, show, S, true, "2층", "A", 3, 70000, date, round, LocalTime.of(14, 0),
+			BOOKED);
+		Seat aSeat = Seat.of(5L, show, A, true, "3층", "A", 2, 50000, date, round, LocalTime.of(14, 0),
+			BOOKED);
+		return List.of(vipSeat1, vipSeat2, sSeat1, sSeat2, aSeat);
+	}
+
 	public static List<Seat> getNonValidSeats(Show show, LocalDate date, int round) {
 		Seat vipSeat1 = Seat.of(show, VIP, false, "1층", "A", 2, 100000, date, round, LocalTime.of(14, 0),
 			AVAILABLE);
@@ -103,5 +119,15 @@ public class TestFixture {
 				it.getSeatStatus()
 			))
 			.toList();
+	}
+
+	public static User getUser(Long id) {
+		return User.testUser(
+			id,
+			"user@email.com",
+			"user",
+			"password",
+			BUYER
+		);
 	}
 }

--- a/core/src/testFixtures/resources/sql/booking_cancel_dummy.sql
+++ b/core/src/testFixtures/resources/sql/booking_cancel_dummy.sql
@@ -8,6 +8,7 @@ INSERT INTO show_table
  show_age_limit, show_total_seats, show_place_id)
 VALUES (1, '레미제라블', 'MUSICAL', '2024-01-01', '2024-12-31', 150, 15, '만 8세 이상', 1000, 1);
 
+
 INSERT INTO seat_table
 (seat_id, seat_show_id, seat_grade, seat_is_seat, seat_sector, seat_row, seat_col, seat_price, seat_show_date,
  seat_show_round, seat_start_time, seat_status)

--- a/scheduler/src/test/java/dev/hooon/waitingbooking/scheduler/WaitingBookingSchedulerTest.java
+++ b/scheduler/src/test/java/dev/hooon/waitingbooking/scheduler/WaitingBookingSchedulerTest.java
@@ -25,7 +25,6 @@ import dev.hooon.show.domain.entity.seat.Seat;
 import dev.hooon.show.domain.entity.seat.SeatStatus;
 import dev.hooon.show.domain.repository.SeatRepository;
 import dev.hooon.user.domain.entity.User;
-import dev.hooon.user.domain.entity.UserRole;
 import dev.hooon.user.domain.repository.UserRepository;
 import dev.hooon.waitingbooking.domain.entity.WaitingBooking;
 import dev.hooon.waitingbooking.domain.entity.WaitingStatus;
@@ -131,8 +130,8 @@ class WaitingBookingSchedulerTest extends TestContainerSupport {
 		User user = User.ofBuyer("hello123@naver.com", "name", "password");
 		userRepository.save(user);
 
-		LocalDateTime beforeNow = LocalDateTime.now().minusSeconds(10);
-		LocalDateTime afterNow = LocalDateTime.now().plusSeconds(10);
+		LocalDateTime beforeNow = LocalDateTime.now().minusMinutes(10);
+		LocalDateTime afterNow = LocalDateTime.now().plusMinutes(10);
 
 		List<WaitingBooking> waitingBookings = List.of(
 			WaitingBookingFixture.getActiveWaitingBooking(


### PR DESCRIPTION
- closed #47 

## 📄 무엇을 개발했나요? 
* 공연 예매 취소 controller, application, repository 구현 및 각 레이어 별 테스트 구현 완료
* 예매 취소 로직이 추가되면서 각 도메인 내에서 validation을 처리해야하는 로직들이 생겨서, 각 도메인 정책에 해당하는 메서드를 추가하였습니다
* 예매 취소 로직에 대해 단위테스트, 그리고 전체 통합테스트를 모두 작성하였습니다

## 🍸 무엇을 집중적으로 리뷰해야할까요?
* 네이밍, 컨벤션 확인
* 예매 취소 비즈니즈 로직 확인 및 점검