### PR TITLE
[feat] : 예매된 좌석 조회 API 구현

### DIFF
--- a/api/src/main/java/dev/hooon/show/ShowSeatsApiController.java
+++ b/api/src/main/java/dev/hooon/show/ShowSeatsApiController.java
@@ -5,12 +5,17 @@ import java.time.LocalDate;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import dev.hooon.show.application.SeatService;
 import dev.hooon.show.application.ShowSeatsService;
+import dev.hooon.show.dto.request.BookedSeatQueryRequest;
+import dev.hooon.show.dto.response.ShowSeatResponse;
 import dev.hooon.show.dto.response.seats.ShowSeatsResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -18,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 public class ShowSeatsApiController {
 
 	private final ShowSeatsService showSeatsService;
+	private final SeatService seatService;
 
 	@GetMapping("/api/shows/{showId}/seats")
 	public ResponseEntity<ShowSeatsResponse> getShowSeatsInfo(
@@ -31,4 +37,11 @@ public class ShowSeatsApiController {
 		return ResponseEntity.ok(showSeatsResponse);
 	}
 
+	@GetMapping("/api/shows/seats/booked")
+	public ResponseEntity<ShowSeatResponse> getBookedSeatInfo(
+		@Valid @ModelAttribute BookedSeatQueryRequest request
+	) {
+		ShowSeatResponse bookedSeatsInfo = seatService.getBookedSeatsInfo(request);
+		return ResponseEntity.ok(bookedSeatsInfo);
+	}
 }

--- a/api/src/test/java/dev/hooon/show/ShowSeatsApiControllerTest.java
+++ b/api/src/test/java/dev/hooon/show/ShowSeatsApiControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import dev.hooon.common.support.ApiTestSupport;
+import dev.hooon.show.domain.entity.seat.SeatStatus;
 
 @DisplayName("[ShowSeatsApiController API 테스트]")
 @Sql("/sql/show_seats_dummy.sql")
@@ -71,4 +72,37 @@ class ShowSeatsApiControllerTest extends ApiTestSupport {
 		);
 	}
 
+	@Test
+	@DisplayName("[[공연 아이디, 날짜, 회차]를 통해 API 를 호출하면 해당 공연의 취소된 좌석 정보를 조회할 수 있다]")
+	void getBookedSeatInfo_test() throws Exception {
+		//when
+		ResultActions resultActions = mockMvc.perform(
+			MockMvcRequestBuilders
+				.get("/api/shows/seats/booked?date=2024-01-01&round=2&showId=1")
+		);
+
+		//then
+		resultActions.andExpectAll(
+			status().isOk(),
+
+			jsonPath("$.seatsDetailInfos.size()").value(2),
+			jsonPath("$.seatsDetailInfos[0].id").exists(),
+			jsonPath("$.seatsDetailInfos[0].date").value("2024-01-01"),
+			jsonPath("$.seatsDetailInfos[0].isSeat").value(true),
+			jsonPath("$.seatsDetailInfos[0].positionInfo_sector").value("1층"),
+			jsonPath("$.seatsDetailInfos[0].positionInfo_row").value("A"),
+			jsonPath("$.seatsDetailInfos[0].positionInfo_col").value("7"),
+			jsonPath("$.seatsDetailInfos[0].price").value(70000),
+			jsonPath("$.seatsDetailInfos[0].status").value(SeatStatus.BOOKED.name()),
+
+			jsonPath("$.seatsDetailInfos[1].id").exists(),
+			jsonPath("$.seatsDetailInfos[1].date").value("2024-01-01"),
+			jsonPath("$.seatsDetailInfos[1].isSeat").value(true),
+			jsonPath("$.seatsDetailInfos[1].positionInfo_sector").value("1층"),
+			jsonPath("$.seatsDetailInfos[1].positionInfo_row").value("A"),
+			jsonPath("$.seatsDetailInfos[1].positionInfo_col").value("8"),
+			jsonPath("$.seatsDetailInfos[1].price").value(50000),
+			jsonPath("$.seatsDetailInfos[1].status").value(SeatStatus.BOOKED.name())
+		);
+	}
 }

--- a/core/src/main/java/dev/hooon/common/config/TimeConfig.java
+++ b/core/src/main/java/dev/hooon/common/config/TimeConfig.java
@@ -1,0 +1,16 @@
+package dev.hooon.common.config;
+
+import java.time.LocalDateTime;
+import java.util.function.Supplier;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeConfig {
+
+	@Bean("nowLocalDateTimeSupplier")
+	public Supplier<LocalDateTime> nowLocalDateTimeSupplier() {
+		return LocalDateTime::now;
+	}
+}

--- a/core/src/main/java/dev/hooon/show/application/PeriodType.java
+++ b/core/src/main/java/dev/hooon/show/application/PeriodType.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.Arrays;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 import dev.hooon.common.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -17,25 +17,25 @@ import lombok.RequiredArgsConstructor;
 public enum PeriodType {
 
 	// 오늘 자정을 기준
-	DAY(() -> LocalDateTime.of(LocalDateTime.now().toLocalDate(), LocalTime.MIDNIGHT)),
+	DAY(baseTime -> LocalDateTime.of(baseTime.toLocalDate(), LocalTime.MIDNIGHT)),
 
 	// 한주의 시작을 목요일로 설정(변경한다면 해당 코드를 변경하면 됨)
-	WEEK(() -> {
-		LocalDate startDate = LocalDateTime.now()
+	WEEK(baseTime -> {
+		LocalDate startDate = baseTime
 			.with(TemporalAdjusters.previousOrSame(DayOfWeek.THURSDAY))
 			.toLocalDate();
 		return LocalDateTime.of(startDate, LocalTime.MIDNIGHT);
 	}),
 
 	// 한달의 시작은 매월 1일
-	MONTH(() -> {
-		LocalDate startDate = LocalDateTime.now()
+	MONTH(baseTime -> {
+		LocalDate startDate = baseTime
 			.with(TemporalAdjusters.firstDayOfMonth())
 			.toLocalDate();
 		return LocalDateTime.of(startDate, LocalTime.MIDNIGHT);
 	});
 
-	private final Supplier<LocalDateTime> startAtSupplier;
+	private final Function<LocalDateTime, LocalDateTime> startAtFunction;
 
 	public static PeriodType of(String target) {
 		return Arrays.stream(values())
@@ -44,7 +44,7 @@ public enum PeriodType {
 			.orElseThrow(() -> new NotFoundException(SHOW_PERIOD_TYPE_NOT_FOUND));
 	}
 
-	public LocalDateTime getStartAt() {
-		return startAtSupplier.get();
+	public LocalDateTime getStartAt(LocalDateTime baseTime) {
+		return startAtFunction.apply(baseTime);
 	}
 }

--- a/core/src/main/java/dev/hooon/show/application/RankingService.java
+++ b/core/src/main/java/dev/hooon/show/application/RankingService.java
@@ -2,6 +2,7 @@ package dev.hooon.show.application;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.function.Supplier;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,12 +20,14 @@ import lombok.RequiredArgsConstructor;
 public class RankingService {
 
 	private final ShowRepository showRepository;
+	private final Supplier<LocalDateTime> nowLocalDateTime;
 
 	@Transactional(readOnly = true)
 	public RankingResponse getShowRanking(RankingRequest rankingRequest) {
 		ShowCategory category = ShowCategory.of(rankingRequest.category());
-		LocalDateTime startAt = PeriodType.of(rankingRequest.period()).getStartAt();
-		LocalDateTime endAt = LocalDateTime.now();
+		LocalDateTime startAt = PeriodType.of(rankingRequest.period())
+			.getStartAt(nowLocalDateTime.get());
+		LocalDateTime endAt = nowLocalDateTime.get();
 
 		List<ShowStatisticDto> showStatistic = showRepository.findShowStatistic(category, startAt, endAt);
 

--- a/core/src/main/java/dev/hooon/show/application/SeatService.java
+++ b/core/src/main/java/dev/hooon/show/application/SeatService.java
@@ -11,6 +11,10 @@ import org.springframework.transaction.annotation.Transactional;
 import dev.hooon.show.domain.entity.seat.Seat;
 import dev.hooon.show.domain.entity.seat.SeatStatus;
 import dev.hooon.show.domain.repository.SeatRepository;
+import dev.hooon.show.dto.SeatMapper;
+import dev.hooon.show.dto.query.seats.SeatsDetailDto;
+import dev.hooon.show.dto.request.BookedSeatQueryRequest;
+import dev.hooon.show.dto.response.ShowSeatResponse;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -41,5 +45,15 @@ public class SeatService {
 
 	public List<Seat> findByIdIn(List<Long> idList) {
 		return seatRepository.findByIdIn(idList);
+	}
+
+	public ShowSeatResponse getBookedSeatsInfo(BookedSeatQueryRequest request) {
+		List<SeatsDetailDto> seatDetails = seatRepository.findBookedSeatsByShowIdAndDateAndRound(
+			request.showId(),
+			request.date(),
+			request.round()
+		);
+
+		return SeatMapper.toShowSeatResponse(seatDetails);
 	}
 }

--- a/core/src/main/java/dev/hooon/show/domain/repository/SeatRepository.java
+++ b/core/src/main/java/dev/hooon/show/domain/repository/SeatRepository.java
@@ -40,4 +40,10 @@ public interface SeatRepository {
 	);
 
 	List<Seat> findByIdIn(List<Long> idList);
+
+	List<SeatsDetailDto> findBookedSeatsByShowIdAndDateAndRound(
+		Long showId,
+		LocalDate date,
+		int round
+	);
 }

--- a/core/src/main/java/dev/hooon/show/dto/SeatMapper.java
+++ b/core/src/main/java/dev/hooon/show/dto/SeatMapper.java
@@ -1,9 +1,12 @@
 package dev.hooon.show.dto;
 
+import static dev.hooon.show.dto.response.ShowSeatResponse.*;
+
 import java.util.List;
 
 import dev.hooon.show.dto.query.seats.SeatsDetailDto;
 import dev.hooon.show.dto.query.seats.SeatsInfoDto;
+import dev.hooon.show.dto.response.ShowSeatResponse;
 import dev.hooon.show.dto.response.seats.SeatsDetailResponse;
 import dev.hooon.show.dto.response.seats.SeatsInfoResponse;
 import lombok.AccessLevel;
@@ -37,4 +40,19 @@ public class SeatMapper {
 			.toList();
 	}
 
+	public static ShowSeatResponse toShowSeatResponse(List<SeatsDetailDto> seatsDetailDtoList) {
+		List<SeatsDetailInfo> seatsDetailInfos = seatsDetailDtoList.stream()
+			.map(dto -> new SeatsDetailInfo(
+				dto.id(),
+				dto.date(),
+				dto.isSeat(),
+				dto.sector(),
+				dto.row(),
+				dto.col(),
+				dto.price(),
+				dto.isBookingAvailable()
+			)).toList();
+
+		return new ShowSeatResponse(seatsDetailInfos);
+	}
 }

--- a/core/src/main/java/dev/hooon/show/dto/request/BookedSeatQueryRequest.java
+++ b/core/src/main/java/dev/hooon/show/dto/request/BookedSeatQueryRequest.java
@@ -1,0 +1,16 @@
+package dev.hooon.show.dto.request;
+
+import java.time.LocalDate;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record BookedSeatQueryRequest(
+	@NotNull
+	Long showId,
+	@NotNull
+	LocalDate date,
+	@Positive
+	int round
+) {
+}

--- a/core/src/main/java/dev/hooon/show/dto/response/ShowSeatResponse.java
+++ b/core/src/main/java/dev/hooon/show/dto/response/ShowSeatResponse.java
@@ -1,0 +1,29 @@
+package dev.hooon.show.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import dev.hooon.show.domain.entity.seat.SeatStatus;
+
+public record ShowSeatResponse(
+	List<SeatsDetailInfo> seatsDetailInfos
+) {
+	public record SeatsDetailInfo(
+		Long id,
+		@JsonFormat(pattern = "yyyy-MM-dd")
+		LocalDate date,
+		boolean isSeat,
+		@JsonProperty("positionInfo_sector")
+		String sector,
+		@JsonProperty("positionInfo_row")
+		String row,
+		@JsonProperty("positionInfo_col")
+		int col,
+		int price,
+		SeatStatus status
+	) {
+	}
+}

--- a/core/src/main/java/dev/hooon/show/infrastructure/adaptor/SeatRepositoryAdaptor.java
+++ b/core/src/main/java/dev/hooon/show/infrastructure/adaptor/SeatRepositoryAdaptor.java
@@ -70,4 +70,18 @@ public class SeatRepositoryAdaptor implements SeatRepository {
 	public List<Seat> findByIdIn(List<Long> idList) {
 		return seatJpaRepository.findByIdIn(idList);
 	}
+
+	@Override
+	public List<SeatsDetailDto> findBookedSeatsByShowIdAndDateAndRound(
+		Long showId,
+		LocalDate date,
+		int round
+	) {
+		return seatJpaRepository.findSeatsDetailByStatusAndDateAndRound(
+			showId,
+			SeatStatus.BOOKED,
+			date,
+			round
+		);
+	}
 }

--- a/core/src/main/java/dev/hooon/show/infrastructure/repository/SeatJpaRepository.java
+++ b/core/src/main/java/dev/hooon/show/infrastructure/repository/SeatJpaRepository.java
@@ -69,4 +69,20 @@ public interface SeatJpaRepository extends JpaRepository<Seat, Long> {
 
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	List<Seat> findByIdIn(List<Long> idList);
+
+	@Query("""
+		select new dev.hooon.show.dto.query.seats.SeatsDetailDto(
+		s.id, s.showDate, s.isSeat, s.positionInfo.sector, s.positionInfo.row, s.positionInfo.col, s.price, s.seatStatus)
+		from Seat s
+		where s.show.id = :showId
+		and s.seatStatus = :status
+		and s.showDate = :date
+		and s.showRound.round = :round
+		""")
+	List<SeatsDetailDto> findSeatsDetailByStatusAndDateAndRound(
+		@Param("showId") Long showId,
+		@Param("status") SeatStatus status,
+		@Param("date") LocalDate date,
+		@Param("round") int round
+	);
 }

--- a/core/src/main/java/dev/hooon/waitingbooking/application/facade/WaitingBookingFacade.java
+++ b/core/src/main/java/dev/hooon/waitingbooking/application/facade/WaitingBookingFacade.java
@@ -87,14 +87,14 @@ public class WaitingBookingFacade {
 	}
 
 	// 6시간동안 예약을 하지않아 만료된 예약대기를 처리
-	public void processExpiredWaitingBooking() {
+	public void processExpiredWaitingBooking(LocalDateTime now) {
 		List<WaitingBooking> waitingBookings = waitingBookingService.getWaitingBookingsByStatusIsActivation();
 
 		List<Long> expiredWaitingBookingIds = new ArrayList<>();
 		List<Long> expiredSeatIds = new ArrayList<>();
 		waitingBookings.forEach(waitingBooking -> {
 			// 만료된 예약대기라면 만료리스트에 추가
-			if (waitingBooking.getExpiredAt().isBefore(LocalDateTime.now())) {
+			if (waitingBooking.getExpiredAt().isBefore(now)) {
 				expiredWaitingBookingIds.add(waitingBooking.getId());
 				expiredSeatIds.addAll(waitingBooking.getConfirmedSeatIds());
 			}

--- a/core/src/test/java/dev/hooon/booking/infrastructure/repository/BookingJpaRepositoryTest.java
+++ b/core/src/test/java/dev/hooon/booking/infrastructure/repository/BookingJpaRepositoryTest.java
@@ -1,8 +1,6 @@
 package dev.hooon.booking.infrastructure.repository;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.*;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,14 +8,12 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import dev.hooon.booking.domain.entity.Booking;
 import dev.hooon.booking.domain.entity.Ticket;
 import dev.hooon.common.fixture.SeatFixture;
 import dev.hooon.common.fixture.TestFixture;
-import dev.hooon.common.support.TestContainerSupport;
+import dev.hooon.common.support.DataJpaTestSupport;
 import dev.hooon.show.domain.entity.Show;
 import dev.hooon.show.domain.entity.place.Place;
 import dev.hooon.show.domain.entity.seat.Seat;
@@ -28,9 +24,7 @@ import dev.hooon.user.domain.entity.User;
 import dev.hooon.user.infrastructure.repository.UserJpaRepository;
 import jakarta.transaction.Transactional;
 
-@SpringBootTest
-@AutoConfigureTestDatabase(replace = NONE)
-class BookingJpaRepositoryTest extends TestContainerSupport {
+class BookingJpaRepositoryTest extends DataJpaTestSupport {
 
 	@Autowired
 	private BookingJpaRepository bookingRepository;
@@ -70,10 +64,9 @@ class BookingJpaRepositoryTest extends TestContainerSupport {
 		Optional<Booking> bookingWithTickets = bookingRepository.findByIdWithTickets(savedBooking.getId());
 
 		// then
-		assertAll(
-			() -> assertThat(bookingWithTickets).isPresent(),
-			() -> assertThat(bookingWithTickets.get().getTickets()).hasSize(2)
-		);
+		assertThat(bookingWithTickets).isPresent();
+		assertThat(bookingWithTickets.get().getTickets()).hasSize(2);
+
 		List<Ticket> tickets = bookingWithTickets.get().getTickets();
 		List<Seat> seats = tickets.stream().map(Ticket::getSeat).toList();
 		assertThat(seats).containsExactlyInAnyOrderElementsOf(List.of(seat1, seat2));

--- a/core/src/test/java/dev/hooon/show/application/PeriodTypeTest.java
+++ b/core/src/test/java/dev/hooon/show/application/PeriodTypeTest.java
@@ -4,7 +4,6 @@ import static dev.hooon.show.exception.ShowErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.DisplayName;
@@ -50,16 +49,18 @@ class PeriodTypeTest {
 		PeriodType week = PeriodType.WEEK;
 		PeriodType month = PeriodType.MONTH;
 
+		LocalDateTime baseTime = LocalDateTime.of(2023, 11, 16, 12, 12);
+
 		//when
-		LocalDateTime dayStartAt = day.getStartAt();
-		LocalDateTime weekStartAt = week.getStartAt();
-		LocalDateTime monthStartAt = month.getStartAt();
+		LocalDateTime dayStartAt = day.getStartAt(baseTime);
+		LocalDateTime weekStartAt = week.getStartAt(baseTime);
+		LocalDateTime monthStartAt = month.getStartAt(baseTime);
 
 		//then
 		assertAll(
-			() -> assertThat(dayStartAt.toLocalDate()).isEqualTo(LocalDate.now()),
-			() -> assertThat(weekStartAt).isBefore(LocalDateTime.now()),
-			() -> assertThat(monthStartAt).isBefore(LocalDateTime.now())
+			() -> assertThat(dayStartAt.toLocalDate()).isEqualTo(baseTime.toLocalDate()),
+			() -> assertThat(weekStartAt).isBefore(baseTime),
+			() -> assertThat(monthStartAt).isBefore(baseTime)
 		);
 
 		log.info("dayStartAt : {}, weekStartAt : {}, monthStartAt : {}", dayStartAt, weekStartAt, monthStartAt);

--- a/core/src/test/java/dev/hooon/show/application/RankingServiceTest.java
+++ b/core/src/test/java/dev/hooon/show/application/RankingServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.BDDMockito.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.function.Supplier;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,8 @@ class RankingServiceTest {
 	private RankingService rankingService;
 	@Mock
 	private ShowRepository showRepository;
+	@Mock
+	private Supplier<LocalDateTime> nowLocalDateTime;
 
 	@Test
 	@DisplayName("[카테고리, 집계기간 별 랭킹을 조회한다]")
@@ -48,12 +51,15 @@ class RankingServiceTest {
 			any(LocalDateTime.class))
 		).willReturn(showStatistic);
 
+		LocalDateTime baseTime = LocalDateTime.of(2023, 11, 16, 12, 12);
+		given(nowLocalDateTime.get()).willReturn(baseTime);
+
 		//when
 		RankingResponse result = rankingService.getShowRanking(rankingRequest);
 
 		//then
-		assertThat(result.aggregateStartAt()).isEqualTo(PeriodType.DAY.getStartAt());
-		assertThat(result.aggregateEndAt()).isEqualToIgnoringMinutes(LocalDateTime.now());
+		assertThat(result.aggregateStartAt()).isEqualTo(PeriodType.DAY.getStartAt(baseTime));
+		assertThat(result.aggregateEndAt()).isEqualToIgnoringMinutes(baseTime);
 		assertThat(result.showInfos()).hasSameSizeAs(showStatistic);
 
 		for (int i = 0; i < showStatistic.size(); i++) {

--- a/core/src/test/java/dev/hooon/show/application/SeatServiceTest.java
+++ b/core/src/test/java/dev/hooon/show/application/SeatServiceTest.java
@@ -1,6 +1,8 @@
 package dev.hooon.show.application;
 
+import static dev.hooon.show.dto.response.ShowSeatResponse.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.util.List;
@@ -14,8 +16,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import dev.hooon.common.fixture.SeatFixture;
+import dev.hooon.common.fixture.TestFixture;
 import dev.hooon.show.domain.entity.seat.Seat;
 import dev.hooon.show.domain.repository.SeatRepository;
+import dev.hooon.show.dto.query.seats.SeatsDetailDto;
+import dev.hooon.show.dto.request.BookedSeatQueryRequest;
+import dev.hooon.show.dto.response.ShowSeatResponse;
 
 @DisplayName("[SeatService 테스트]")
 @ExtendWith(MockitoExtension.class)
@@ -27,7 +33,8 @@ class SeatServiceTest {
 	private SeatRepository seatRepository;
 
 	@Test
-	void getCanceledSeatIds() {
+	@DisplayName("[취소된 좌석들의 id 를 조회한다]")
+	void getCanceledSeatIds_test() {
 		//given
 		List<Seat> seats = List.of(
 			SeatFixture.getSeat(1L),
@@ -43,5 +50,44 @@ class SeatServiceTest {
 		//then
 		assertThat(result).hasSameSizeAs(seats);
 		seats.forEach(seat -> assertThat(result).contains(seat.getId()));
+	}
+
+	@Test
+	@DisplayName("[예약된 좌석들의 정보를 조회한다]")
+	void getBookedSeatsInfo_test() {
+		//given
+		List<Seat> seats = List.of(
+			SeatFixture.getSeat(1L),
+			SeatFixture.getSeat(2L),
+			SeatFixture.getSeat(3L)
+		);
+		List<SeatsDetailDto> seatsDetails = TestFixture.seatListToSeatsDetailDto(seats);
+
+		given(seatRepository.findBookedSeatsByShowIdAndDateAndRound(1L, seats.get(0).getShowDate(), 1))
+			.willReturn(seatsDetails);
+
+		BookedSeatQueryRequest request = new BookedSeatQueryRequest(1L, seats.get(0).getShowDate(), 1);
+
+		//when
+		ShowSeatResponse result = seatService.getBookedSeatsInfo(request);
+
+		//then
+		List<SeatsDetailInfo> seatsDetailInfos = result.seatsDetailInfos();
+
+		for (int i = 0; i < seatsDetailInfos.size(); i++) {
+			SeatsDetailInfo actual = seatsDetailInfos.get(i);
+			SeatsDetailDto expected = seatsDetails.get(i);
+
+			assertAll(
+				() -> assertThat(actual.id()).isEqualTo(expected.id()),
+				() -> assertThat(actual.isSeat()).isEqualTo(expected.isSeat()),
+				() -> assertThat(actual.col()).isEqualTo(expected.col()),
+				() -> assertThat(actual.row()).isEqualTo(expected.row()),
+				() -> assertThat(actual.date()).isEqualTo(expected.date()),
+				() -> assertThat(actual.price()).isEqualTo(expected.price()),
+				() -> assertThat(actual.sector()).isEqualTo(expected.sector()),
+				() -> assertThat(actual.status()).isEqualTo(expected.isBookingAvailable())
+			);
+		}
 	}
 }

--- a/core/src/test/java/dev/hooon/show/application/facade/RankingCacheFacadeTest.java
+++ b/core/src/test/java/dev/hooon/show/application/facade/RankingCacheFacadeTest.java
@@ -36,14 +36,16 @@ class RankingCacheFacadeTest {
 	@Mock
 	private ObjectMapper objectMapper;
 
+	private final LocalDateTime baseTime = LocalDateTime.of(2023, 11, 16, 12, 12);
+
 	@Test
 	@DisplayName("[캐시에 해당 카테고리, 집계기간에 대한 데이터가 있어서 캐시에서 데이터를 조회한다]")
 	void getShowRankingWithCache_test_1() {
 		//given
 		RankingRequest rankingRequest = new RankingRequest("concert", "day");
 		RankingResponse rankingResponse = new RankingResponse(
-			PeriodType.DAY.getStartAt(),
-			LocalDateTime.now(),
+			PeriodType.DAY.getStartAt(baseTime),
+			baseTime,
 			new ArrayList<>()
 		);
 
@@ -67,7 +69,7 @@ class RankingCacheFacadeTest {
 		//given
 		RankingRequest rankingRequest = new RankingRequest("concert", "day");
 		RankingResponse rankingResponse = new RankingResponse(
-			PeriodType.DAY.getStartAt(),
+			PeriodType.DAY.getStartAt(baseTime),
 			LocalDateTime.now(),
 			new ArrayList<>()
 		);

--- a/core/src/test/java/dev/hooon/show/domain/repository/SeatRepositoryTest.java
+++ b/core/src/test/java/dev/hooon/show/domain/repository/SeatRepositoryTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import dev.hooon.common.fixture.SeatFixture;
+import dev.hooon.common.fixture.TestFixture;
 import dev.hooon.common.support.DataJpaTestSupport;
 import dev.hooon.show.domain.entity.Show;
 import dev.hooon.show.domain.entity.ShowCategory;
@@ -22,6 +23,7 @@ import dev.hooon.show.domain.entity.place.Place;
 import dev.hooon.show.domain.entity.seat.Seat;
 import dev.hooon.show.domain.entity.seat.SeatStatus;
 import dev.hooon.show.dto.query.SeatDateRoundDto;
+import dev.hooon.show.dto.query.seats.SeatsDetailDto;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 
@@ -149,7 +151,6 @@ class SeatRepositoryTest extends DataJpaTestSupport {
 	@Test
 	@DisplayName("[id 리스트에 포함된 좌석들을 조회할 수 있다]")
 	void findByIdInTest() {
-
 		// given
 		List<Seat> seats = List.of(
 			SeatFixture.getSeat(),
@@ -167,4 +168,31 @@ class SeatRepositoryTest extends DataJpaTestSupport {
 		assertEquals(seatList, seats);
 	}
 
+	@Test
+	@DisplayName("[공연 id 와 공연날짜, 회차 정보로 예매된 좌석 정보를 조회한다]")
+	void findBookedSeatsByShowIdAndDateAndRound_test() {
+		//given
+		List<Seat> seats = List.of(
+			SeatFixture.getSeat(),
+			SeatFixture.getSeat(),
+			SeatFixture.getSeat()
+		);
+		seats.get(1).markSeatStatusAsBooked();
+		seats.get(2).markSeatStatusAsBooked();
+		seatRepository.saveAll(seats);
+
+		List<SeatsDetailDto> expected = TestFixture.seatListToSeatsDetailDto(seats);
+
+		//when
+		List<SeatsDetailDto> result = seatRepository.findBookedSeatsByShowIdAndDateAndRound(
+			1L,
+			seats.get(0).getShowDate(),
+			seats.get(0).getRound()
+		);
+
+		//then
+		assertThat(result)
+			.hasSize(2)
+			.contains(expected.get(1), expected.get(2));
+	}
 }

--- a/core/src/test/java/dev/hooon/waitingbooking/application/facade/WaitingBookingFacadeTest.java
+++ b/core/src/test/java/dev/hooon/waitingbooking/application/facade/WaitingBookingFacadeTest.java
@@ -99,8 +99,9 @@ class WaitingBookingFacadeTest {
 	@DisplayName("[만료된 활성화 상태인 예약대기를 처리한다]")
 	void processExpiredWaitingBooking_test() {
 		//given
-		LocalDateTime beforeNow = LocalDateTime.now().minusSeconds(10);
-		LocalDateTime afterNow = LocalDateTime.now().plusSeconds(10);
+		LocalDateTime now = LocalDateTime.of(2023, 11, 16, 12, 12);
+		LocalDateTime beforeNow = now.minusSeconds(10);
+		LocalDateTime afterNow = now.plusSeconds(10);
 		List<WaitingBooking> waitingBookings = List.of(
 			WaitingBookingFixture.getActiveWaitingBooking(1L, beforeNow, 2, List.of(1L, 2L)),
 			WaitingBookingFixture.getActiveWaitingBooking(2L, beforeNow, 2, List.of(3L, 4L)),
@@ -111,7 +112,7 @@ class WaitingBookingFacadeTest {
 			.willReturn(waitingBookings);
 
 		//when
-		waitingBookingFacade.processExpiredWaitingBooking();
+		waitingBookingFacade.processExpiredWaitingBooking(now);
 
 		//then
 		verify(waitingBookingService, times(1)).expireActiveWaitingBooking(anyList());

--- a/core/src/testFixtures/java/dev/hooon/common/support/IntegrationTestSupport.java
+++ b/core/src/testFixtures/java/dev/hooon/common/support/IntegrationTestSupport.java
@@ -1,7 +1,11 @@
 package dev.hooon.common.support;
 
+import java.time.LocalDateTime;
+import java.util.function.Supplier;
+
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureTestEntityManager;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -11,4 +15,7 @@ public abstract class IntegrationTestSupport extends TestContainerSupport {
 
 	protected IntegrationTestSupport() {
 	}
+
+	@MockBean
+	protected Supplier<LocalDateTime> nowLocalDateTime;
 }

--- a/core/src/testFixtures/resources/sql/show_seats_dummy.sql
+++ b/core/src/testFixtures/resources/sql/show_seats_dummy.sql
@@ -32,3 +32,13 @@ INSERT INTO seat_table
 (seat_show_id, seat_grade, seat_is_seat, seat_sector, seat_row, seat_col, seat_price, seat_show_date,
  seat_show_round, seat_start_time, seat_status)
 VALUES (1, 'A', true, '3층', 'A', 2, 50000, '2024-01-01', 2, '13:00:00', 'AVAILABLE');
+
+INSERT INTO seat_table
+(seat_show_id, seat_grade, seat_is_seat, seat_sector, seat_row, seat_col, seat_price, seat_show_date,
+ seat_show_round, seat_start_time, seat_status)
+VALUES (1, 'S', true, '1층', 'A', 7, 70000, '2024-01-01', 2, '13:00:00', 'BOOKED');
+
+INSERT INTO seat_table
+(seat_show_id, seat_grade, seat_is_seat, seat_sector, seat_row, seat_col, seat_price, seat_show_date,
+ seat_show_round, seat_start_time, seat_status)
+VALUES (1, 'A', true, '1층', 'A', 8, 50000, '2024-01-01', 2, '13:00:00', 'BOOKED');

--- a/scheduler/src/main/java/dev/hooon/waitingbooking/scheduler/WaitingBookingScheduler.java
+++ b/scheduler/src/main/java/dev/hooon/waitingbooking/scheduler/WaitingBookingScheduler.java
@@ -1,5 +1,8 @@
 package dev.hooon.waitingbooking.scheduler;
 
+import java.time.LocalDateTime;
+import java.util.function.Supplier;
+
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -15,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 public class WaitingBookingScheduler {
 
 	private final WaitingBookingFacade waitingBookingFacade;
+	private final Supplier<LocalDateTime> nowLocalDateTIme;
 
 	@Scheduled(cron = "0 0/10 * * * *")
 	@SchedulerLock(name = "wb_1", lockAtLeastFor = "9m", lockAtMostFor = "15m")
@@ -26,7 +30,7 @@ public class WaitingBookingScheduler {
 	@Scheduled(cron = "0/5 * * * * *")
 	@SchedulerLock(name = "wb_2", lockAtLeastFor = "4s", lockAtMostFor = "8s")
 	public void scheduleExpiredWaitingBookingProcess() {
-		log.info("wb_2 : run : run");
-		waitingBookingFacade.processExpiredWaitingBooking();
+		log.info("wb_2 : run");
+		waitingBookingFacade.processExpiredWaitingBooking(nowLocalDateTIme.get());
 	}
 }

--- a/scheduler/src/test/java/dev/hooon/show/scheduler/RankingSchedulerTest.java
+++ b/scheduler/src/test/java/dev/hooon/show/scheduler/RankingSchedulerTest.java
@@ -1,7 +1,9 @@
 package dev.hooon.show.scheduler;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
@@ -61,6 +63,8 @@ class RankingSchedulerTest extends IntegrationTestSupport {
 			Booking.of(user, shows.get(2))
 		);
 		bookings.forEach(booking -> bookingRepository.save(booking));
+
+		given(nowLocalDateTime.get()).willReturn(LocalDateTime.of(2023, 11, 16, 12, 12));
 
 		//when
 		rankingScheduler.cacheEvictRanking();

--- a/scheduler/src/test/java/dev/hooon/waitingbooking/scheduler/WaitingBookingSchedulerTest.java
+++ b/scheduler/src/test/java/dev/hooon/waitingbooking/scheduler/WaitingBookingSchedulerTest.java
@@ -122,8 +122,11 @@ class WaitingBookingSchedulerTest extends IntegrationTestSupport {
 		User user = User.ofBuyer("hello123@naver.com", "name", "password");
 		userRepository.save(user);
 
-		LocalDateTime beforeNow = LocalDateTime.now().minusMinutes(10);
-		LocalDateTime afterNow = LocalDateTime.now().plusMinutes(10);
+		LocalDateTime now = LocalDateTime.of(2023, 11, 16, 12, 12);
+		LocalDateTime beforeNow = now.minusSeconds(10);
+		LocalDateTime afterNow = now.plusSeconds(10);
+		// 스케줄러 기준시간 동적으로 조정
+		given(nowLocalDateTime.get()).willReturn(now);
 
 		List<WaitingBooking> waitingBookings = List.of(
 			WaitingBookingFixture.getActiveWaitingBooking(


### PR DESCRIPTION
## 📄 무엇을 개발했나요? 
* 예매대기에 사용되는 예매된 좌석 조회 API 구현(repository, service, controller)
* 기존에 간헐적으로 터지는 시간관련 테스트를 현재시간을 의존성 주입받아서 사용하도록 코드르 수정하여 해결

## 🍸 무엇을 집중적으로 리뷰해야할까요?
* 앞쪽커밋은 쭉 개발관련 커밋이고 마지막 두커밋이 리팩토링 커밋입니다
* 시간 의존성 주입과 API 집중 리뷰 부탁드려요