### PR TITLE
[feat] : 사용자는 카테고리별로 전체 공연의 정보를 조회할 수 있다

### DIFF
--- a/api/src/main/java/dev/hooon/show/ShowsApiController.java
+++ b/api/src/main/java/dev/hooon/show/ShowsApiController.java
@@ -1,0 +1,31 @@
+package dev.hooon.show;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import dev.hooon.auth.annotation.NoAuth;
+import dev.hooon.show.application.ShowService;
+import dev.hooon.show.dto.response.ShowInfoResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class ShowsApiController {
+
+	private final ShowService showService;
+
+	@NoAuth
+	@GetMapping("/api/shows/")
+	public ResponseEntity<List<ShowInfoResponse>> getAbleBookingDateRoundInfo(
+		@RequestParam("page") int page,
+		@RequestParam("size") int size,
+		@RequestParam("category") String category
+	) {
+		List<ShowInfoResponse> responses = showService.getShowsByCategory(page, size, category);
+		return ResponseEntity.ok(responses);
+	}
+}

--- a/api/src/main/java/dev/hooon/show/ShowsApiController.java
+++ b/api/src/main/java/dev/hooon/show/ShowsApiController.java
@@ -1,13 +1,12 @@
 package dev.hooon.show;
 
-import java.util.List;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import dev.hooon.auth.annotation.NoAuth;
+import dev.hooon.common.dto.PagedResponse;
 import dev.hooon.show.application.ShowService;
 import dev.hooon.show.dto.response.ShowInfoResponse;
 import jakarta.validation.constraints.Min;
@@ -22,12 +21,13 @@ public class ShowsApiController {
 
 	@NoAuth
 	@GetMapping("/api/shows")
-	public ResponseEntity<List<ShowInfoResponse>> getAbleBookingDateRoundInfo(
+	public ResponseEntity<PagedResponse<ShowInfoResponse>> getShowsByCategory(
 		@RequestParam("page") @Min(0) int page,
 		@RequestParam("size") @Min(1) int size,
 		@RequestParam("category") @NotBlank String category
 	) {
-		List<ShowInfoResponse> responses = showService.getShowsByCategory(page, size, category);
-		return ResponseEntity.ok(responses);
+		return ResponseEntity.ok(
+			showService.getShowsByCategory(page, size, category)
+		);
 	}
 }

--- a/api/src/main/java/dev/hooon/show/ShowsApiController.java
+++ b/api/src/main/java/dev/hooon/show/ShowsApiController.java
@@ -19,7 +19,7 @@ public class ShowsApiController {
 	private final ShowService showService;
 
 	@NoAuth
-	@GetMapping("/api/shows/")
+	@GetMapping("/api/shows")
 	public ResponseEntity<List<ShowInfoResponse>> getAbleBookingDateRoundInfo(
 		@RequestParam("page") int page,
 		@RequestParam("size") int size,

--- a/api/src/main/java/dev/hooon/show/ShowsApiController.java
+++ b/api/src/main/java/dev/hooon/show/ShowsApiController.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.RestController;
 import dev.hooon.auth.annotation.NoAuth;
 import dev.hooon.show.application.ShowService;
 import dev.hooon.show.dto.response.ShowInfoResponse;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -21,9 +23,9 @@ public class ShowsApiController {
 	@NoAuth
 	@GetMapping("/api/shows")
 	public ResponseEntity<List<ShowInfoResponse>> getAbleBookingDateRoundInfo(
-		@RequestParam("page") int page,
-		@RequestParam("size") int size,
-		@RequestParam("category") String category
+		@RequestParam("page") @Min(0) int page,
+		@RequestParam("size") @Min(1) int size,
+		@RequestParam("category") @NotBlank String category
 	) {
 		List<ShowInfoResponse> responses = showService.getShowsByCategory(page, size, category);
 		return ResponseEntity.ok(responses);

--- a/api/src/main/java/dev/hooon/show/ShowsApiController.java
+++ b/api/src/main/java/dev/hooon/show/ShowsApiController.java
@@ -9,10 +9,14 @@ import dev.hooon.auth.annotation.NoAuth;
 import dev.hooon.common.dto.PagedResponse;
 import dev.hooon.show.application.ShowService;
 import dev.hooon.show.dto.response.ShowInfoResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "Show API")
 @RestController
 @RequiredArgsConstructor
 public class ShowsApiController {
@@ -21,6 +25,8 @@ public class ShowsApiController {
 
 	@NoAuth
 	@GetMapping("/api/shows")
+	@Operation(summary = "카테고리별로 공연 전체조회 API", description = "선택한 카테고리의 전체 공연의 공연 이름, 장소 이름을 조회한다")
+	@ApiResponse(responseCode = "200", useReturnTypeSchema = true)
 	public ResponseEntity<PagedResponse<ShowInfoResponse>> getShowsByCategory(
 		@RequestParam("page") @Min(0) int page,
 		@RequestParam("size") @Min(1) int size,

--- a/api/src/test/java/dev/hooon/show/ShowsApiControllerTest.java
+++ b/api/src/test/java/dev/hooon/show/ShowsApiControllerTest.java
@@ -1,0 +1,68 @@
+package dev.hooon.show;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import dev.hooon.common.fixture.TestFixture;
+import dev.hooon.common.support.ApiTestSupport;
+import dev.hooon.show.domain.entity.Show;
+import dev.hooon.show.domain.entity.ShowCategory;
+import dev.hooon.show.domain.entity.place.Place;
+import dev.hooon.show.domain.repository.PlaceRepository;
+import dev.hooon.show.domain.repository.ShowRepository;
+
+@DisplayName("[ShowsApiController API 테스트]")
+class ShowsApiControllerTest extends ApiTestSupport {
+
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private ShowRepository showRepository;
+	@Autowired
+	private PlaceRepository placeRepository;
+
+
+	@DisplayName("[올바른 공연 목록이 반환된다]")
+	@Test
+	void getShowsByCategoryTest() throws Exception {
+		// Given
+		Place place = TestFixture.getPlace();
+		placeRepository.save(place);
+		String placeName = place.getName();
+		Show show1 = TestFixture.getShow(place, "레미제라블", ShowCategory.MUSICAL);
+		Show show2 = TestFixture.getShow(place, "서울의 봄", ShowCategory.PLAY);
+		Show show3 = TestFixture.getShow(place, "노량", ShowCategory.PLAY);
+		showRepository.save(show1);
+		showRepository.save(show2);
+		showRepository.save(show3);
+
+		int page = 0;
+		int size = 3;
+		String categoryPicked = "PLAY";
+
+		// When
+		ResultActions resultActions = mockMvc.perform(
+			MockMvcRequestBuilders
+				.get("/api/shows/")
+				.param("page", String.valueOf(page))
+				.param("size", String.valueOf(size))
+				.param("category", categoryPicked)
+		);
+
+		// Then
+		resultActions.andExpectAll(
+			status().isOk(),
+			jsonPath("$.size()").value(2),
+			jsonPath("$[0].showName").value("서울의 봄"),
+			jsonPath("$[0].placeName").value(placeName),
+			jsonPath("$[1].showName").value("노량"),
+			jsonPath("$[1].placeName").value(placeName)
+		);
+	}
+}

--- a/api/src/test/java/dev/hooon/show/ShowsApiControllerTest.java
+++ b/api/src/test/java/dev/hooon/show/ShowsApiControllerTest.java
@@ -49,7 +49,7 @@ class ShowsApiControllerTest extends ApiTestSupport {
 		// When
 		ResultActions resultActions = mockMvc.perform(
 			MockMvcRequestBuilders
-				.get("/api/shows/")
+				.get("/api/shows")
 				.param("page", String.valueOf(page))
 				.param("size", String.valueOf(size))
 				.param("category", categoryPicked)

--- a/api/src/test/java/dev/hooon/show/ShowsApiControllerTest.java
+++ b/api/src/test/java/dev/hooon/show/ShowsApiControllerTest.java
@@ -21,12 +21,9 @@ import dev.hooon.show.domain.repository.ShowRepository;
 class ShowsApiControllerTest extends ApiTestSupport {
 
 	@Autowired
-	private MockMvc mockMvc;
-	@Autowired
 	private ShowRepository showRepository;
 	@Autowired
 	private PlaceRepository placeRepository;
-
 
 	@DisplayName("[올바른 공연 목록이 반환된다]")
 	@Test
@@ -65,4 +62,35 @@ class ShowsApiControllerTest extends ApiTestSupport {
 			jsonPath("$[1].placeName").value(placeName)
 		);
 	}
+
+	@Test
+	@DisplayName("[0보다 작은 페이지 번호가 주어지면 400 오류를 반환한다]")
+	void givenInvalidPage_whenGetShowsByCategory_thenReturnsBadRequest() throws Exception {
+		mockMvc.perform(MockMvcRequestBuilders.get("/api/shows")
+				.param("page", "-1")
+				.param("size", "3")
+				.param("category", "PLAY"))
+			.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	@DisplayName("[1보다 작은 사이즈가 주어지면 400 오류를 반환한다]")
+	void givenInvalidSize_whenGetShowsByCategory_thenReturnsBadRequest() throws Exception {
+		mockMvc.perform(MockMvcRequestBuilders.get("/api/shows")
+				.param("page", "0")
+				.param("size", "0")
+				.param("category", "PLAY"))
+			.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	@DisplayName("[비어있는 String 이 카테고리로 주어지면 400 오류를 반환한다]")
+	void givenInvalidCategory_whenGetShowsByCategory_thenReturnsBadRequest() throws Exception {
+		mockMvc.perform(MockMvcRequestBuilders.get("/api/shows")
+				.param("page", "0")
+				.param("size", "3")
+				.param("category", ""))
+			.andExpect(status().isBadRequest());
+	}
+
 }

--- a/api/src/test/java/dev/hooon/show/ShowsApiControllerTest.java
+++ b/api/src/test/java/dev/hooon/show/ShowsApiControllerTest.java
@@ -55,10 +55,14 @@ class ShowsApiControllerTest extends ApiTestSupport {
 		resultActions.andExpectAll(
 			status().isOk(),
 			jsonPath("$.content.size()").value(2),
-			jsonPath("$.content[0].showName").value("서울의 봄"),
+			jsonPath("$.content[0].showName").value("노량"),
 			jsonPath("$.content[0].placeName").value(placeName),
-			jsonPath("$.content[1].showName").value("노량"),
-			jsonPath("$.content[1].placeName").value(placeName)
+			jsonPath("$.content[1].showName").value("서울의 봄"),
+			jsonPath("$.content[1].placeName").value(placeName),
+			jsonPath("$.totalPages").value(1),
+			jsonPath("$.totalItems").value(2),
+			jsonPath("$.currentPage").value(0),
+			jsonPath("$.pageSize").value(3)
 		);
 	}
 

--- a/api/src/test/java/dev/hooon/show/ShowsApiControllerTest.java
+++ b/api/src/test/java/dev/hooon/show/ShowsApiControllerTest.java
@@ -5,7 +5,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -55,11 +54,11 @@ class ShowsApiControllerTest extends ApiTestSupport {
 		// Then
 		resultActions.andExpectAll(
 			status().isOk(),
-			jsonPath("$.size()").value(2),
-			jsonPath("$[0].showName").value("서울의 봄"),
-			jsonPath("$[0].placeName").value(placeName),
-			jsonPath("$[1].showName").value("노량"),
-			jsonPath("$[1].placeName").value(placeName)
+			jsonPath("$.content.size()").value(2),
+			jsonPath("$.content[0].showName").value("서울의 봄"),
+			jsonPath("$.content[0].placeName").value(placeName),
+			jsonPath("$.content[1].showName").value("노량"),
+			jsonPath("$.content[1].placeName").value(placeName)
 		);
 	}
 

--- a/core/src/main/java/dev/hooon/auth/application/JwtProvider.java
+++ b/core/src/main/java/dev/hooon/auth/application/JwtProvider.java
@@ -49,7 +49,7 @@ public class JwtProvider {
 			.setHeaderParam("type", "jwt")
 			.claim(USER_ID, userId)
 			.setIssuedAt(now)
-			.setExpiration(new Date(now.getTime() + tokenValidSeconds))
+			.setExpiration(new Date(now.getTime() + tokenValidSeconds * 1000L))
 			.signWith(key, SignatureAlgorithm.HS256)
 			.compact();
 	}
@@ -61,7 +61,7 @@ public class JwtProvider {
 			.setHeaderParam("type", "jwt")
 			.claim(USER_ID, userId)
 			.setIssuedAt(now)
-			.setExpiration(new Date(now.getTime() + tokenValidSeconds * 30L))
+			.setExpiration(new Date(now.getTime() + tokenValidSeconds * 1000L * 30))
 			.signWith(key, SignatureAlgorithm.HS256)
 			.compact();
 	}

--- a/core/src/main/java/dev/hooon/auth/infrastructure/adaptor/AuthRepositoryAdaptor.java
+++ b/core/src/main/java/dev/hooon/auth/infrastructure/adaptor/AuthRepositoryAdaptor.java
@@ -8,9 +8,7 @@ import dev.hooon.auth.domain.entity.Auth;
 import dev.hooon.auth.domain.repository.AuthRepository;
 import dev.hooon.auth.infrastructure.AuthJpaRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class AuthRepositoryAdaptor implements AuthRepository {

--- a/core/src/main/java/dev/hooon/common/dto/PagedResponse.java
+++ b/core/src/main/java/dev/hooon/common/dto/PagedResponse.java
@@ -1,0 +1,12 @@
+package dev.hooon.common.dto;
+
+import java.util.List;
+
+public record PagedResponse<T>(
+	List<T> content,
+	int totalPages,
+	int totalItems,
+	int currentPage,
+	int pageSize
+) {
+}

--- a/core/src/main/java/dev/hooon/show/application/ShowService.java
+++ b/core/src/main/java/dev/hooon/show/application/ShowService.java
@@ -2,19 +2,25 @@ package dev.hooon.show.application;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import dev.hooon.common.exception.NotFoundException;
 import dev.hooon.show.domain.entity.Show;
+import dev.hooon.show.domain.entity.ShowCategory;
 import dev.hooon.show.domain.repository.SeatRepository;
 import dev.hooon.show.domain.repository.ShowRepository;
 import dev.hooon.show.dto.ShowMapper;
 import dev.hooon.show.dto.query.SeatDateRoundDto;
 import dev.hooon.show.dto.response.AbleBookingDateRoundResponse;
 import dev.hooon.show.dto.response.ShowDetailsInfoResponse;
+import dev.hooon.show.dto.response.ShowInfoResponse;
 import dev.hooon.show.exception.ShowErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ShowService {
@@ -33,5 +39,17 @@ public class ShowService {
 			() -> new NotFoundException(ShowErrorCode.SHOW_NOT_FOUND)
 		);
 		return ShowMapper.toShowDetailInfoResponse(show);
+	}
+
+	public List<ShowInfoResponse> getShowsByCategory(int page, int size, String category) {
+		ShowCategory showCategory = ShowCategory.of(category);
+		PageRequest pageRequest = PageRequest.of(page, size);
+		Page<Show> showsPage = showRepository.findByCategory(showCategory, pageRequest);
+
+		if (showsPage.hasContent()) {
+			return showsPage.map(ShowInfoResponse::of).getContent();
+		} else {
+			return List.of();
+		}
 	}
 }

--- a/core/src/main/java/dev/hooon/show/application/ShowService.java
+++ b/core/src/main/java/dev/hooon/show/application/ShowService.java
@@ -43,7 +43,7 @@ public class ShowService {
 	public PagedResponse<ShowInfoResponse> getShowsByCategory(int page, int size, String category) {
 		ShowCategory showCategory = ShowCategory.of(category);
 		PageRequest pageRequest = PageRequest.of(page, size);
-		Page<Show> showsPage = showRepository.findByCategory(showCategory, pageRequest);
+		Page<Show> showsPage = showRepository.findByCategoryOrderByIdDesc(showCategory, pageRequest);
 		List<ShowInfoResponse> content = showsPage.map(ShowMapper::toShowInfoResponse).getContent();
 
 		return new PagedResponse<>(

--- a/core/src/main/java/dev/hooon/show/application/ShowService.java
+++ b/core/src/main/java/dev/hooon/show/application/ShowService.java
@@ -18,9 +18,7 @@ import dev.hooon.show.dto.response.ShowDetailsInfoResponse;
 import dev.hooon.show.dto.response.ShowInfoResponse;
 import dev.hooon.show.exception.ShowErrorCode;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ShowService {
@@ -46,10 +44,6 @@ public class ShowService {
 		PageRequest pageRequest = PageRequest.of(page, size);
 		Page<Show> showsPage = showRepository.findByCategory(showCategory, pageRequest);
 
-		if (showsPage.hasContent()) {
-			return showsPage.map(ShowInfoResponse::of).getContent();
-		} else {
-			return List.of();
-		}
+		return showsPage.map(ShowMapper::toShowInfoResponse).getContent();
 	}
 }

--- a/core/src/main/java/dev/hooon/show/application/ShowService.java
+++ b/core/src/main/java/dev/hooon/show/application/ShowService.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
+import dev.hooon.common.dto.PagedResponse;
 import dev.hooon.common.exception.NotFoundException;
 import dev.hooon.show.domain.entity.Show;
 import dev.hooon.show.domain.entity.ShowCategory;
@@ -39,11 +40,18 @@ public class ShowService {
 		return ShowMapper.toShowDetailInfoResponse(show);
 	}
 
-	public List<ShowInfoResponse> getShowsByCategory(int page, int size, String category) {
+	public PagedResponse<ShowInfoResponse> getShowsByCategory(int page, int size, String category) {
 		ShowCategory showCategory = ShowCategory.of(category);
 		PageRequest pageRequest = PageRequest.of(page, size);
 		Page<Show> showsPage = showRepository.findByCategory(showCategory, pageRequest);
+		List<ShowInfoResponse> content = showsPage.map(ShowMapper::toShowInfoResponse).getContent();
 
-		return showsPage.map(ShowMapper::toShowInfoResponse).getContent();
+		return new PagedResponse<>(
+			content,
+			showsPage.getTotalPages(),
+			showsPage.getNumberOfElements(),
+			showsPage.getNumber(),
+			showsPage.getSize()
+		);
 	}
 }

--- a/core/src/main/java/dev/hooon/show/domain/repository/ShowRepository.java
+++ b/core/src/main/java/dev/hooon/show/domain/repository/ShowRepository.java
@@ -4,6 +4,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import dev.hooon.show.domain.entity.Show;
 import dev.hooon.show.domain.entity.ShowCategory;
 import dev.hooon.show.dto.query.ShowStatisticDto;
@@ -19,4 +22,6 @@ public interface ShowRepository {
 		LocalDateTime startAt,
 		LocalDateTime endAt
 	);
+
+	Page<Show> findByCategory(ShowCategory category, Pageable pageable);
 }

--- a/core/src/main/java/dev/hooon/show/domain/repository/ShowRepository.java
+++ b/core/src/main/java/dev/hooon/show/domain/repository/ShowRepository.java
@@ -23,5 +23,5 @@ public interface ShowRepository {
 		LocalDateTime endAt
 	);
 
-	Page<Show> findByCategory(ShowCategory category, Pageable pageable);
+	Page<Show> findByCategoryOrderByIdDesc(ShowCategory category, Pageable pageable);
 }

--- a/core/src/main/java/dev/hooon/show/dto/ShowMapper.java
+++ b/core/src/main/java/dev/hooon/show/dto/ShowMapper.java
@@ -13,6 +13,7 @@ import dev.hooon.show.dto.response.AbleBookingDateRoundResponse.AvailableDate;
 import dev.hooon.show.dto.response.PlaceDetailsInfo;
 import dev.hooon.show.dto.response.RankingResponse;
 import dev.hooon.show.dto.response.ShowDetailsInfoResponse;
+import dev.hooon.show.dto.response.ShowInfoResponse;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -65,6 +66,13 @@ public final class ShowMapper {
 			startAt,
 			endAt,
 			rankingShowInfos
+		);
+	}
+
+	public static ShowInfoResponse toShowInfoResponse(Show show) {
+		return new ShowInfoResponse(
+			show.getName(),
+			show.getPlace().getName()
 		);
 	}
 }

--- a/core/src/main/java/dev/hooon/show/dto/response/ShowInfoResponse.java
+++ b/core/src/main/java/dev/hooon/show/dto/response/ShowInfoResponse.java
@@ -1,0 +1,14 @@
+package dev.hooon.show.dto.response;
+
+import dev.hooon.show.domain.entity.Show;
+
+public record ShowInfoResponse(
+	String showName,
+	String placeName
+) {
+	public static ShowInfoResponse of(
+		Show show
+	) {
+		return new ShowInfoResponse(show.getName(), show.getPlace().getName());
+	}
+}

--- a/core/src/main/java/dev/hooon/show/dto/response/ShowInfoResponse.java
+++ b/core/src/main/java/dev/hooon/show/dto/response/ShowInfoResponse.java
@@ -1,14 +1,7 @@
 package dev.hooon.show.dto.response;
 
-import dev.hooon.show.domain.entity.Show;
-
 public record ShowInfoResponse(
 	String showName,
 	String placeName
 ) {
-	public static ShowInfoResponse of(
-		Show show
-	) {
-		return new ShowInfoResponse(show.getName(), show.getPlace().getName());
-	}
 }

--- a/core/src/main/java/dev/hooon/show/infrastructure/adaptor/ShowRepositoryAdaptor.java
+++ b/core/src/main/java/dev/hooon/show/infrastructure/adaptor/ShowRepositoryAdaptor.java
@@ -41,7 +41,7 @@ public class ShowRepositoryAdaptor implements ShowRepository {
 	}
 
 	@Override
-	public Page<Show> findByCategory(ShowCategory category, Pageable pageable) {
+	public Page<Show> findByCategoryOrderByIdDesc(ShowCategory category, Pageable pageable) {
 		return showJpaRepository.findByCategoryOrderByIdDesc(category, pageable);
 	}
 

--- a/core/src/main/java/dev/hooon/show/infrastructure/adaptor/ShowRepositoryAdaptor.java
+++ b/core/src/main/java/dev/hooon/show/infrastructure/adaptor/ShowRepositoryAdaptor.java
@@ -42,7 +42,7 @@ public class ShowRepositoryAdaptor implements ShowRepository {
 
 	@Override
 	public Page<Show> findByCategory(ShowCategory category, Pageable pageable) {
-		return showJpaRepository.findByCategory(category, pageable);
+		return showJpaRepository.findByCategoryOrderByIdDesc(category, pageable);
 	}
 
 }

--- a/core/src/main/java/dev/hooon/show/infrastructure/adaptor/ShowRepositoryAdaptor.java
+++ b/core/src/main/java/dev/hooon/show/infrastructure/adaptor/ShowRepositoryAdaptor.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import dev.hooon.show.domain.entity.Show;
@@ -37,4 +39,10 @@ public class ShowRepositoryAdaptor implements ShowRepository {
 	) {
 		return showJpaRepository.findBookingStatisticByCategoryAndPeriod(category, startAt, endAt);
 	}
+
+	@Override
+	public Page<Show> findByCategory(ShowCategory category, Pageable pageable) {
+		return showJpaRepository.findByCategory(category, pageable);
+	}
+
 }

--- a/core/src/main/java/dev/hooon/show/infrastructure/repository/ShowJpaRepository.java
+++ b/core/src/main/java/dev/hooon/show/infrastructure/repository/ShowJpaRepository.java
@@ -32,6 +32,6 @@ public interface ShowJpaRepository extends JpaRepository<Show, Long> {
 		@Param("endAt") LocalDateTime endAt
 	);
 
-	Page<Show> findByCategory(ShowCategory category, Pageable pageable);
+	Page<Show> findByCategoryOrderByIdDesc(ShowCategory category, Pageable pageable);
 
 }

--- a/core/src/main/java/dev/hooon/show/infrastructure/repository/ShowJpaRepository.java
+++ b/core/src/main/java/dev/hooon/show/infrastructure/repository/ShowJpaRepository.java
@@ -3,6 +3,8 @@ package dev.hooon.show.infrastructure.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -29,4 +31,7 @@ public interface ShowJpaRepository extends JpaRepository<Show, Long> {
 		@Param("startAt") LocalDateTime startAt,
 		@Param("endAt") LocalDateTime endAt
 	);
+
+	Page<Show> findByCategory(ShowCategory category, Pageable pageable);
+
 }

--- a/core/src/test/java/dev/hooon/auth/application/JwtProviderTest.java
+++ b/core/src/test/java/dev/hooon/auth/application/JwtProviderTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.security.Key;
-import java.util.Date;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -59,7 +58,7 @@ class JwtProviderTest {
 		assertThat(claims.getIssuedAt()).isNotNull();
 		assertThat(claims.getExpiration()).isNotNull();
 		assertThat(claims.getExpiration().getTime() - claims.getIssuedAt().getTime())
-			.isCloseTo(tokenValidSeconds, within(1000L));    // 토큰 생성 자체에 드는 시간 고려
+			.isCloseTo(tokenValidSeconds * 1000L, within(1000L));    // 토큰 생성 자체에 드는 시간 고려
 	}
 
 	@Test
@@ -83,7 +82,7 @@ class JwtProviderTest {
 		assertThat(claims.getIssuedAt()).isNotNull();
 		assertThat(claims.getExpiration()).isNotNull();
 		assertThat(claims.getExpiration().getTime() - claims.getIssuedAt().getTime())
-			.isCloseTo(tokenValidSeconds * 30L, within(1000L));    // 토큰 생성 자체에 드는 시간 고려
+			.isCloseTo(tokenValidSeconds * 1000L * 30, within(1000L));    // 토큰 생성 자체에 드는 시간 고려
 	}
 
 	@Test


### PR DESCRIPTION
## 📄 무엇을 개발했나요? 
- 사용자가 카테고리별로 전체 공연의 정보를 조회할 수 있도록 하는 api 입니다

## 🍸 무엇을 집중적으로 리뷰해야할까요?
- 페이징을 다루는 로직에서 어색한 부분이 있는지 궁금합니다.

- 그리고 저희 api 의 Response 에는 정렬 기준이 없지만  
- **테스트코드에서는 api 의 Response 에 두 개의 show 가 들어가있도록 했고**, 
- 우선 [0]번과 [1]번을 값 검증 했더니 어떤 기준인지는 모르겠지만 정렬이 되어있더라구요!
- 이에 대한 의견이 궁금합니다. (default 정렬 기준이 있는걸까?)


```
resultActions.andExpectAll(
			status().isOk(),
			jsonPath("$.size()").value(2),
			jsonPath("$[0].showName").value("서울의 봄"),
			jsonPath("$[0].placeName").value(placeName),
			jsonPath("$[1].showName").value("노량"),
			jsonPath("$[1].placeName").value(placeName)
		);
```