### PR TITLE
[feat] : 로그아웃 api 구현 + 토큰 재발급 관리 로직 추가

### DIFF
--- a/api/src/main/java/dev/hooon/auth/AuthApiController.java
+++ b/api/src/main/java/dev/hooon/auth/AuthApiController.java
@@ -1,5 +1,6 @@
 package dev.hooon.auth;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -10,9 +11,10 @@ import dev.hooon.auth.annotation.NoAuth;
 import dev.hooon.auth.application.AuthService;
 import dev.hooon.auth.dto.TokenReIssueRequest;
 import dev.hooon.auth.dto.request.AuthRequest;
-
 import dev.hooon.auth.dto.response.AuthResponse;
+import dev.hooon.auth.jwt.JwtAuthorization;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -35,6 +37,16 @@ public class AuthApiController {
 	) {
 		AuthResponse authResponse = authService.login(authRequest);
 		return ResponseEntity.ok(authResponse);
+	}
+
+	@PostMapping("/logout")
+	@Operation(summary = "로그아웃 API", description = "로그아웃을 한다")
+	@ApiResponse(responseCode = "200", useReturnTypeSchema = true)
+	public ResponseEntity<HttpStatus> logout(
+		@Parameter(hidden = true) @JwtAuthorization Long userId
+	) {
+		authService.logout(userId);
+		return ResponseEntity.ok(HttpStatus.OK);
 	}
 
 	@NoAuth

--- a/api/src/test/java/dev/hooon/auth/AuthApiControllerTest.java
+++ b/api/src/test/java/dev/hooon/auth/AuthApiControllerTest.java
@@ -29,19 +29,18 @@ class AuthApiControllerTest extends ApiTestSupport {
 	private UserService userService;
 	@Autowired
 	private AuthService authService;
+	private AuthRequest authRequest;
 
 	@BeforeEach
 	void setUp() {
 		UserJoinRequest userJoinRequest = new UserJoinRequest("user@example.com", "password123", "name123");
 		userService.join(userJoinRequest);
+		authRequest = new AuthRequest("user@example.com", "password123");
 	}
 
 	@Test
 	@DisplayName("[로그인 API를 호출하면 토큰이 응답된다]")
 	void loginTest() throws Exception {
-		// given
-		AuthRequest authRequest = new AuthRequest("user@example.com", "password123");
-
 		// when
 		ResultActions actions = mockMvc.perform(
 			post("/api/auth/login")
@@ -59,7 +58,6 @@ class AuthApiControllerTest extends ApiTestSupport {
 	@DisplayName("[토큰 재발급 API를 호출하면 새로운 엑세스 토큰이 응답된다]")
 	void reIssueAccessTokenTest() throws Exception {
 		// given
-		AuthRequest authRequest = new AuthRequest("user@example.com", "password123");
 		AuthResponse authResponse = authService.login(authRequest);
 		String refreshToken = authResponse.refreshToken();
 		TokenReIssueRequest tokenReIssueRequest = new TokenReIssueRequest(refreshToken);
@@ -74,5 +72,22 @@ class AuthApiControllerTest extends ApiTestSupport {
 		// then
 		actions.andExpect(status().isOk())
 			.andExpect(content().string(not(emptyOrNullString())));
+	}
+
+	@Test
+	@DisplayName("[로그아웃 API를 호출하면 200 OK 응답이 반환된다]")
+	void logoutTest() throws Exception {
+		// given
+		AuthResponse authResponse = authService.login(authRequest);
+		String accessToken = authResponse.accessToken();
+
+		// when
+		ResultActions actions = mockMvc.perform(
+			post("/api/auth/logout")
+				.header("Authorization", accessToken)
+		);
+
+		// then
+		actions.andExpect(status().isOk());
 	}
 }

--- a/core/src/main/java/dev/hooon/auth/domain/entity/Auth.java
+++ b/core/src/main/java/dev/hooon/auth/domain/entity/Auth.java
@@ -1,11 +1,8 @@
 package dev.hooon.auth.domain.entity;
 
-import static dev.hooon.common.exception.CommonValidationError.*;
 import static jakarta.persistence.GenerationType.*;
 
-import org.springframework.util.Assert;
-
-import dev.hooon.user.domain.entity.UserRole;
+import dev.hooon.common.entity.TimeBaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -18,7 +15,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @Table(name = "auth_table")
-public class Auth {
+public class Auth extends TimeBaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = IDENTITY)

--- a/core/src/main/java/dev/hooon/auth/domain/entity/BlacklistToken.java
+++ b/core/src/main/java/dev/hooon/auth/domain/entity/BlacklistToken.java
@@ -1,0 +1,35 @@
+package dev.hooon.auth.domain.entity;
+
+import static jakarta.persistence.GenerationType.*;
+
+import dev.hooon.common.entity.TimeBaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "blacklist_token_table")
+public class BlacklistToken extends TimeBaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	@Column(name = "blacklist_token_id")
+	private Long id;
+
+	@Column(name = "blacklist_token_refresh_token", nullable = false, unique = true)
+	private String refreshToken;
+
+	private BlacklistToken(String refreshToken) {
+		this.refreshToken = refreshToken;
+	}
+
+	public static BlacklistToken of(String refreshToken) {
+		return new BlacklistToken(refreshToken);
+	}
+}

--- a/core/src/main/java/dev/hooon/auth/domain/repository/BlacklistRepository.java
+++ b/core/src/main/java/dev/hooon/auth/domain/repository/BlacklistRepository.java
@@ -1,0 +1,10 @@
+package dev.hooon.auth.domain.repository;
+
+import dev.hooon.auth.domain.entity.BlacklistToken;
+
+public interface BlacklistRepository {
+
+	boolean existsByRefreshToken(String refreshToken);
+
+	void save(BlacklistToken blacklistToken);
+}

--- a/core/src/main/java/dev/hooon/auth/exception/AuthErrorCode.java
+++ b/core/src/main/java/dev/hooon/auth/exception/AuthErrorCode.java
@@ -17,7 +17,8 @@ public enum AuthErrorCode implements ErrorCode {
 	NOT_FOUND_USER_ID("해당 유저의 인증 데이터가 존재하지 않습니다.", "A_007"),
 	TOKEN_EXPIRED("토큰이 만료 시간을 초과했습니다.", "A_008"),
 	UNSUPPORTED_TOKEN("토큰 유형이 지원되지 않습니다.", "A_010"),
-	MALFORMED_TOKEN("토큰의 구조가 올바르지 않습니다.", "A_011");
+	MALFORMED_TOKEN("토큰의 구조가 올바르지 않습니다.", "A_011"),
+	BLACKLISTED_TOKEN("해당 토큰은 블랙리스트에 등록되어있으므로 유효하지 않습니다.", "A_012");
 
 	private final String message;
 	private final String code;

--- a/core/src/main/java/dev/hooon/auth/infrastructure/BlacklistJpaRepository.java
+++ b/core/src/main/java/dev/hooon/auth/infrastructure/BlacklistJpaRepository.java
@@ -1,0 +1,9 @@
+package dev.hooon.auth.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import dev.hooon.auth.domain.entity.BlacklistToken;
+
+public interface BlacklistJpaRepository extends JpaRepository<BlacklistToken, Long> {
+	boolean existsByRefreshToken(String refreshToken);
+}

--- a/core/src/main/java/dev/hooon/auth/infrastructure/adaptor/AuthRepositoryAdaptor.java
+++ b/core/src/main/java/dev/hooon/auth/infrastructure/adaptor/AuthRepositoryAdaptor.java
@@ -8,9 +8,7 @@ import dev.hooon.auth.domain.entity.Auth;
 import dev.hooon.auth.domain.repository.AuthRepository;
 import dev.hooon.auth.infrastructure.AuthJpaRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class AuthRepositoryAdaptor implements AuthRepository {

--- a/core/src/main/java/dev/hooon/auth/infrastructure/adaptor/BlacklistRepositoryAdaptor.java
+++ b/core/src/main/java/dev/hooon/auth/infrastructure/adaptor/BlacklistRepositoryAdaptor.java
@@ -1,0 +1,25 @@
+package dev.hooon.auth.infrastructure.adaptor;
+
+import org.springframework.stereotype.Repository;
+
+import dev.hooon.auth.domain.entity.BlacklistToken;
+import dev.hooon.auth.domain.repository.BlacklistRepository;
+import dev.hooon.auth.infrastructure.BlacklistJpaRepository;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class BlacklistRepositoryAdaptor implements BlacklistRepository {
+
+	private final BlacklistJpaRepository blacklistJpaRepository;
+
+	@Override
+	public boolean existsByRefreshToken(String refreshToken) {
+		return blacklistJpaRepository.existsByRefreshToken(refreshToken);
+	}
+
+	@Override
+	public void save(BlacklistToken blacklistToken) {
+		blacklistJpaRepository.save(blacklistToken);
+	}
+}


### PR DESCRIPTION
## 📄 무엇을 개발했나요? 
- 토큰 블랙리스트 관리로 로그아웃을 구현해봤습니다.  (한 스푼의 Stateful)
- 로그아웃한 사용자의 Refresh Token은 블랙리스트의 역할을 하는 DB에 저장합니다.
- Access Token이 만료되어 Refresh Token으로 새로운 Access Token을 요청하는 경우에도, 서버는 블랙리스트에 해당 Refresh Token이 저장되어 있는 것을 확인하고, 해당 Refresh Token은 로그아웃된 유저라는 것을 알 수 있기 때문에 Access Token 재발급을 거절할 수 있습니다.
- 조금 stateful 하지만, 악성 해커가 계속해서 판을 치는 것을 방지하면서도, Access Token이 만료되었을 때 Refresh Token을 통해 재발급을 받아 너무 자주 로그인이 풀리는 것을 방지해서 사용자 경험도 향상될 수 있습니다.
- 서버 측에서는 블랙리스트를 관리하여 무효화된 토큰을 거부할 수 있습니다.

## 🍸 무엇을 집중적으로 리뷰해야할까요?
- 로직에 어긋나는 부분이나 부족한 점이 있다면 얘기해주세요!





